### PR TITLE
Add --port option to scargo flash

### DIFF
--- a/scargo/__init__.py
+++ b/scargo/__init__.py
@@ -173,9 +173,13 @@ def flash(
     flash_profile: str = Option(
         "Debug", "--profile", help="Flash base on previously built profile"
     ),
+    port: Optional[str] = Option(
+        None,
+        help="port where the target device of the command is connected to, e.g. /dev/ttyUSB0",
+    ),
 ):
     """Flash the target (only available for esp32 for now)."""
-    scargo_flash(app, file_system, flash_profile)
+    scargo_flash(app, file_system, flash_profile, port)
 
 
 ###############################################################################


### PR DESCRIPTION
Closes #52

I've verified that both parttool.py and esptool.py have the --port option, however st-flash does not have anything like this, so it seems that it can only be supported for esp32 targets.