### PR TITLE
Improve the relevance of test output

### DIFF
--- a/run.py
+++ b/run.py
@@ -116,7 +116,6 @@ def perform_tests(test_path: str, test_postfix: str, *test_flags: str) -> str:
             "--cov=scargo",
             "--gherkin-terminal-reporter",
             "-v",
-            "-s",
             test_path,
         ]
 

--- a/tests/it/utils.py
+++ b/tests/it/utils.py
@@ -36,6 +36,7 @@ class ScargoTestRunner(CliRunner):
             **extra,
         )
         sys.argv = temp
+        print(result.output)
         return result
 
 


### PR DESCRIPTION
There are two problems with the current test setup:
* `-s` option for `pytest` causes all output to be shown, which includes a lot of irrelevant output of passing tests
* output from docker commands in integration tests is hidden, which makes them really unhelpful, not giving any details about what went wrong

This PR removes the `-s` option and adds docker output for failing tests.