### PR TITLE
Fix/command multiline copyrights string fix

### DIFF
--- a/scargo/commands/check.py
+++ b/scargo/commands/check.py
@@ -204,7 +204,10 @@ class CopyrightChecker(CheckerFixer):
 
         with open(file_path, "w", encoding="utf-8") as file:
             file.write("//\n")
-            file.write(f"// {self.copyright_desc}\n")
+            for line in self.copyright_desc.split("\n"):
+                if line == "":
+                    continue
+                file.write(f"// {line}\n")
             file.write("//\n")
             file.write("\n")
             file.write(old)

--- a/scargo/commands/check.py
+++ b/scargo/commands/check.py
@@ -205,9 +205,8 @@ class CopyrightChecker(CheckerFixer):
         with open(file_path, "w", encoding="utf-8") as file:
             file.write("//\n")
             for line in self.copyright_desc.split("\n"):
-                if line == "":
-                    continue
-                file.write(f"// {line}\n")
+                if line != "":
+                    file.write(f"// {line}\n")
             file.write("//\n")
             file.write("\n")
             file.write(old)


### PR DESCRIPTION
Fixed issue with fix --copyrights command for multiline string.