### PR TITLE
Drop docker-compose==1.29.2 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can find all information on how to work with scargo on official documentatio
 # Project dependencies
 ## Working with docker (recommended)
 - docker
-- docker-compose version 1.29.2
+- docker-compose
 - pip
 - python3
 

--- a/example_project/README.md
+++ b/example_project/README.md
@@ -47,5 +47,5 @@ to update the environment with your credential.
 - pip
 - scargo
 - docker
-- docker-compose version 1.29.2
+- docker-compose
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "cmake==3.25.2",
     "coloredlogs==15.0.1",
     "conan==1.59.0",
-    "docker-compose==1.29.2",
     "docker==6.0.1",
     "esptool==4.5.1",
     "jinja2==3.1.2",

--- a/scargo/jinja/templates/README.md.j2
+++ b/scargo/jinja/templates/README.md.j2
@@ -50,7 +50,7 @@ to update the environment with your credential.
 - pip
 - scargo
 - docker
-- docker-compose version 1.29.2
+- docker-compose
 
 {% if project.target.family == "esp32" %}
 # ESP32 configure

--- a/tests/it/test_projects/common_scargo_project/README.md
+++ b/tests/it/test_projects/common_scargo_project/README.md
@@ -51,5 +51,5 @@ to update the environment with your credential.
 - pip
 - scargo
 - docker
-- docker-compose version 1.29.2
+- docker-compose
 

--- a/tests/it/test_projects/common_scargo_project_esp32/README.md
+++ b/tests/it/test_projects/common_scargo_project_esp32/README.md
@@ -48,7 +48,7 @@ to update the environment with your credential.
 - pip
 - scargo
 - docker
-- docker-compose version 1.29.2
+- docker-compose
 
 # ESP32 configure
 On the beginning of project is strongly recommended to configure the project using `idf.py menuconfig`

--- a/tests/it/test_projects/common_scargo_project_stm32/README.md
+++ b/tests/it/test_projects/common_scargo_project_stm32/README.md
@@ -48,7 +48,7 @@ to update the environment with your credential.
 - pip
 - scargo
 - docker
-- docker-compose version 1.29.2
+- docker-compose
 
 # STM32 configure
 External dependencies are delivered with conan package "stm32_cmake/0.1.0" . It consist of cmsis and HAL from stm.


### PR DESCRIPTION
Should fix #117.

There's no reason to require docker-compose as a Python dependency. We really don't need it installed in our docker images.

And a big reason not to do it is that Python implementation of docker-compose is outdated (it has been rewritten to Golang and only this version is being supported). Also, since it's old, it depends on old versions of other packages, which causes conflicts.