### PR TITLE
Source files folder for gcovr

### DIFF
--- a/scargo/commands/test.py
+++ b/scargo/commands/test.py
@@ -6,6 +6,7 @@
 import subprocess
 import sys
 from pathlib import Path
+from typing import List, Union
 
 from scargo.config import Config
 from scargo.config_utils import prepare_config
@@ -56,7 +57,7 @@ def scargo_test(verbose: bool) -> None:
 
 def run_ut(config: Config, verbose: bool, cwd: Path) -> None:
     # Run tests.
-    cmd = ["ctest"]
+    cmd: List[Union[str, Path]] = ["ctest"]
 
     if verbose:
         cmd.append("--verbose")
@@ -66,7 +67,16 @@ def run_ut(config: Config, verbose: bool, cwd: Path) -> None:
         subprocess.run(cmd, cwd=cwd, check=False)
 
         # Run code coverage.
-        cmd = ["gcovr", "-r", "ut", ".", "--html", "ut-coverage.html"]
+        cmd = [
+            "gcovr",
+            "-r",
+            "ut",
+            ".",
+            "-f",
+            config.project_root.joinpath(config.project.target.source_dir),
+            "--html",
+            "ut-coverage.html",
+        ]
 
         gcov_executable = config.tests.gcov_executable
 

--- a/tests/ut/ut_scargo_test.py
+++ b/tests/ut/ut_scargo_test.py
@@ -26,6 +26,7 @@ def test_scargo_test_no_cmake_file(
 def test_scargo_test(create_new_project: None, fp: FakeProcess) -> None:
     project_root = get_project_root_or_none()
     assert project_root is not None
+    src_dir = project_root / "src"
     tests_src_dir = project_root / "tests"
     test_build_dir = project_root / "build/tests"
     html_coverage_file = "ut-coverage.html"
@@ -33,5 +34,5 @@ def test_scargo_test(create_new_project: None, fp: FakeProcess) -> None:
     fp.register(f"conan install {tests_src_dir} -if {test_build_dir}")
     fp.register(f"conan build {tests_src_dir} -bf {test_build_dir}")
     fp.register("ctest")
-    fp.register(f"gcovr -r ut . --html {html_coverage_file}")
+    fp.register(f"gcovr -r ut . -f {src_dir} --html {html_coverage_file}")
     scargo_test(False)


### PR DESCRIPTION
Add option --filter to gcovr command line, it specifies a folder where gcovr should look for source files.

The default is -root and for us it is inside build folder.

This is the page that I got: 
![ut-coverage-page](https://user-images.githubusercontent.com/129379442/230615578-eb478949-4ba1-44fa-af5f-8ee4f361b70c.png)

https://gcovr.com/en/stable/manpage.html#cmdoption-gcovr-f https://github.com/Spyro-Soft/scargo/issues/137