### PR TITLE
Use CMake directly to build tests

### DIFF
--- a/scargo/cli.py
+++ b/scargo/cli.py
@@ -404,12 +404,13 @@ def run(
 @cli.command()
 def test(
     verbose: bool = Option(False, "--verbose", "-v", help="Verbose mode."),
+    profile: str = Option("Debug", "--profile", help="CMake profile to use"),
     base_dir: Optional[Path] = BASE_DIR_OPTION,
 ) -> None:
     """Compile and run all tests in directory `test`."""
     if base_dir:
         os.chdir(base_dir)
-    scargo_test(verbose)
+    scargo_test(verbose, profile)
 
 
 ###############################################################################

--- a/scargo/commands/test.py
+++ b/scargo/commands/test.py
@@ -12,10 +12,11 @@ from scargo.config_utils import prepare_config
 from scargo.logger import get_logger
 
 
-def scargo_test(verbose: bool) -> None:
+def scargo_test(verbose: bool, profile: str = "Debug") -> None:
     """
     Run test
     :param bool verbose: if verbose
+    :param str profile: CMake profile to use
     """
     logger = get_logger()
     config = prepare_config()
@@ -43,8 +44,11 @@ def scargo_test(verbose: bool) -> None:
             cwd=project_dir,
         )
         subprocess.check_call(
-            ["conan", "build", tests_src_dir, "-bf", test_build_dir],
-            cwd=project_dir,
+            ["cmake", f"-DCMAKE_BUILD_TYPE={profile}", tests_src_dir],
+            cwd=test_build_dir,
+        )
+        subprocess.check_call(
+            "cmake --build . --parallel", shell=True, cwd=test_build_dir
         )
     except subprocess.CalledProcessError:
         logger.error("Failed to build tests.")

--- a/tests/ut/ut_scargo_test.py
+++ b/tests/ut/ut_scargo_test.py
@@ -31,7 +31,8 @@ def test_scargo_test(create_new_project: None, fp: FakeProcess) -> None:
     html_coverage_file = "ut-coverage.html"
 
     fp.register(f"conan install {tests_src_dir} -if {test_build_dir}")
-    fp.register(f"conan build {tests_src_dir} -bf {test_build_dir}")
+    fp.register(f"cmake -DCMAKE_BUILD_TYPE=Debug {tests_src_dir}")
+    fp.register("cmake --build . --parallel")
     fp.register("ctest")
     fp.register(f"gcovr -r ut . --html {html_coverage_file}")
     scargo_test(False)


### PR DESCRIPTION
Use CMake debug profile by default for unit tests to avoid optimization. Proper solution would be to use custom Conan profile, but this should be synchronized with updating other cmake calls across all supported commands.

Fixes #138 