### PR TITLE
Check and update CMakeLists in every dir

### DIFF
--- a/scargo/file_generators/ut_gen.py
+++ b/scargo/file_generators/ut_gen.py
@@ -80,7 +80,10 @@ class _UnitTestsGen:
         :param Path src_dir_path: Source directory for which tests are being generated
         :param Path ut_dir_path: Directory of generated unit tests
         """
-        add_subdirs_to_cmake(ut_dir_path.relative_to(self._project_path))
+        cmake_dir_path = ut_dir_path
+        while cmake_dir_path != self._ut_dir.parent:
+            add_subdirs_to_cmake(cmake_dir_path.relative_to(self._project_path))
+            cmake_dir_path = cmake_dir_path.parent
 
         ut_name = self._get_cmake_tests_name(ut_dir_path)
         ut_files = [


### PR DESCRIPTION
Before, when creating unt tests using scargo gen command, it was only modifying CMakeLists file in the parent directory of unit tests file (not touching folders above in path).

Right now, it is checking and updating CMakeLists file on every level of path between tests directory and unit tests file directory.

I am not familiar with embeded software and structure of C projects, please verify additionaly if it is not breaking anything.

https://github.com/Spyro-Soft/scargo/issues/134