### PR TITLE
Improve check command output

### DIFF
--- a/tests/ut/scargo_check/ut_checker_fixer.py
+++ b/tests/ut/scargo_check/ut_checker_fixer.py
@@ -105,9 +105,8 @@ class TestCheckerFixer:
         config: Config,
         mock_find_files: MagicMock,
     ) -> None:
-        with pytest.raises(SystemExit) as wrapped_exception:
-            checker_class(config).check()
-        assert wrapped_exception.value.code == 1
+        result = checker_class(config).check()
+        assert result == 1
         expected = [
             ("INFO", "Starting failing check..."),
             ("INFO", "Finished failing check. Found problems in 1 files."),

--- a/tests/ut/scargo_check/ut_clang_format_checker.py
+++ b/tests/ut/scargo_check/ut_clang_format_checker.py
@@ -28,7 +28,8 @@ def test_check_clang_format_pass(
     fake_process: FakeProcess,
 ) -> None:
     fake_process.register(CLANG_FORMAT_COMMAND)
-    ClangFormatChecker(config).check()
+    result = ClangFormatChecker(config).check()
+    assert result == 0
     assert all(
         level not in ("WARNING", "ERROR") for level, msg in get_log_data(caplog.records)
     )
@@ -52,9 +53,8 @@ def test_check_clang_format_fail(
     fake_process.register(
         CLANG_FORMAT_COMMAND, stdout=CLANG_FORMAT_ERROR_OUTPUT, returncode=1
     )
-    with pytest.raises(SystemExit) as wrapped_exception:
-        ClangFormatChecker(config, verbose=verbose).check()
-    assert wrapped_exception.value.code == 1
+    result = ClangFormatChecker(config, verbose=verbose).check()
+    assert result == 1
     assert expected_message in get_log_data(caplog.records)
 
 
@@ -65,5 +65,6 @@ def test_check_clang_format_fix(
         CLANG_FORMAT_COMMAND, stdout=CLANG_FORMAT_ERROR_OUTPUT, returncode=1
     )
     fake_process.register(CLANG_FORMAT_FIX_COMMAND)
-    ClangFormatChecker(config, fix_errors=True).check()
+    result = ClangFormatChecker(config, fix_errors=True).check()
+    assert result == 1
     assert fake_process.call_count(CLANG_FORMAT_FIX_COMMAND) == 1

--- a/tests/ut/scargo_check/ut_clang_tidy_checker.py
+++ b/tests/ut/scargo_check/ut_clang_tidy_checker.py
@@ -21,7 +21,8 @@ def test_check_clang_tidy_pass(
     fake_process: FakeProcess,
 ) -> None:
     fake_process.register(CLANG_TIDY_COMMAND, stdout=CLANG_TIDY_NORMAL_OUTPUT)
-    ClangTidyChecker(config).check()
+    result = ClangTidyChecker(config).check()
+    assert result == 0
     assert all(
         level not in ("WARNING", "ERROR") for level, msg in get_log_data(caplog.records)
     )
@@ -45,7 +46,6 @@ def test_check_clang_tidy_fail(
     fake_process.register(
         CLANG_TIDY_COMMAND, stdout=CLANG_TIDY_ERROR_OUTPUT, returncode=1
     )
-    with pytest.raises(SystemExit) as wrapped_exception:
-        ClangTidyChecker(config, verbose=verbose).check()
-    assert wrapped_exception.value.code == 1
+    result = ClangTidyChecker(config, verbose=verbose).check()
+    assert result == 1
     assert expected_message in get_log_data(caplog.records)

--- a/tests/ut/scargo_check/ut_copyright_checker.py
+++ b/tests/ut/scargo_check/ut_copyright_checker.py
@@ -23,11 +23,7 @@ FILE_CONTENTS_WITH_INCORRECT_COPYRIGHT = [
     "int main(void);",
 ]
 
-MISSING_COPYRIGHT_WARNING = ("INFO", "Missing copyright in foo/bar.hpp.")
-INCORRECT_COPYRIGHT_WARNING = (
-    "WARNING",
-    "Incorrect and not excluded copyright in foo/bar.hpp",
-)
+MISSING_COPYRIGHT_WARNING = ("WARNING", "Missing copyright line in foo/bar.hpp.")
 
 
 @pytest.mark.parametrize(
@@ -41,7 +37,9 @@ def test_check_copyright_pass(
     config: Config,
     mock_find_files: MagicMock,
 ) -> None:
-    CopyrightChecker(config).check()
+    result = CopyrightChecker(config).check()
+
+    assert result == 0
     assert all(level != "WARNING" for level, msg in get_log_data(caplog.records))
 
 
@@ -56,13 +54,11 @@ def test_check_copyright_fail(
     config: Config,
     mock_find_files: MagicMock,
 ) -> None:
-    with pytest.raises(SystemExit) as wrapped_exception:
-        CopyrightChecker(config).check()
+    result = CopyrightChecker(config).check()
 
-    assert wrapped_exception.value.code == 1
+    assert result == 1
     log_data = get_log_data(caplog.records)
     assert MISSING_COPYRIGHT_WARNING in log_data
-    assert INCORRECT_COPYRIGHT_WARNING not in log_data
 
 
 @pytest.mark.parametrize(
@@ -106,8 +102,12 @@ def test_check_copyright_no_description(
 ) -> None:
     config.check.copyright.description = None
 
-    CopyrightChecker(config).check()
+    result = CopyrightChecker(config).check()
 
+    assert result == 0
     assert get_log_data(caplog.records) == [
-        ("WARNING", "No copyrights in defined in toml")
+        (
+            "WARNING",
+            "No copyright line defined in scargo.toml at check.copyright.description",
+        )
     ]

--- a/tests/ut/scargo_check/ut_cppcheck_checker.py
+++ b/tests/ut/scargo_check/ut_cppcheck_checker.py
@@ -19,8 +19,9 @@ def test_cppcheck_checker_pass(
 ) -> None:
     fake_process.register(CPPCHECK_COMMAND)
 
-    CppcheckChecker(config=config).check()
+    result = CppcheckChecker(config=config).check()
 
+    assert result == 0
     assert fake_process.call_count(CPPCHECK_COMMAND) == 1
     assert get_log_data(caplog.records) == [
         ("INFO", "Starting cppcheck check..."),
@@ -33,6 +34,7 @@ def test_cppcheck_checker_fail(
 ) -> None:
     fake_process.register(CPPCHECK_COMMAND, returncode=1)
 
-    CppcheckChecker(config=config).check()
+    result = CppcheckChecker(config=config).check()
 
-    assert ("ERROR", "cppcheck fail") in get_log_data(caplog.records)
+    assert result == 0
+    assert ("ERROR", "cppcheck fail!") in get_log_data(caplog.records)

--- a/tests/ut/scargo_check/ut_cyclomatic_checker.py
+++ b/tests/ut/scargo_check/ut_cyclomatic_checker.py
@@ -13,7 +13,8 @@ def test_cyclomatic_checker_pass(
 ) -> None:
     fake_process.register(LIZARD_COMMAND)
 
-    CyclomaticChecker(config=config).check()
+    result = CyclomaticChecker(config=config).check()
+    assert result == 0
 
     assert fake_process.call_count(LIZARD_COMMAND) == 1
     assert get_log_data(caplog.records) == [
@@ -27,9 +28,10 @@ def test_cyclomatic_checker_fail(
 ) -> None:
     fake_process.register(LIZARD_COMMAND, returncode=1)
 
-    CyclomaticChecker(config=config).check()
+    result = CyclomaticChecker(config=config).check()
+    assert result == 0
 
-    assert ("ERROR", "ERROR: Check cyclomatic fail") in get_log_data(caplog.records)
+    assert ("ERROR", "cyclomatic fail!") in get_log_data(caplog.records)
 
 
 def test_cyclomatic_checker_exclude(
@@ -39,6 +41,7 @@ def test_cyclomatic_checker_exclude(
     command_with_exclude = LIZARD_COMMAND + ["--exclude", "foo/*"]
     fake_process.register(command_with_exclude)
 
-    CyclomaticChecker(config=config).check()
+    result = CyclomaticChecker(config=config).check()
+    assert result == 0
 
     assert fake_process.call_count(command_with_exclude) == 1

--- a/tests/ut/scargo_check/ut_pragma_checker.py
+++ b/tests/ut/scargo_check/ut_pragma_checker.py
@@ -27,7 +27,8 @@ def test_check_pragma_pass(
     config: Config,
     mock_find_files: MagicMock,
 ) -> None:
-    PragmaChecker(config).check()
+    result = PragmaChecker(config).check()
+    assert result == 0
     assert ("WARNING", "Missing pragma in foo/bar.hpp") not in get_log_data(
         caplog.records
     )
@@ -44,10 +45,11 @@ def test_check_pragma_fail(
     config: Config,
     mock_find_files: MagicMock,
 ) -> None:
-    with pytest.raises(SystemExit) as wrapped_exception:
-        PragmaChecker(config).check()
-    assert wrapped_exception.value.code == 1
-    assert ("WARNING", "Missing pragma in foo/bar.hpp") in get_log_data(caplog.records)
+    result = PragmaChecker(config).check()
+    assert result == 1
+    assert ("WARNING", "Missing 'pragma #once' in foo/bar.hpp") in get_log_data(
+        caplog.records
+    )
 
 
 @pytest.mark.parametrize(
@@ -58,7 +60,8 @@ def test_check_pragma_fail(
 def test_check_pragma_fix(
     mock_file_contents: MagicMock, config: Config, mock_find_files: MagicMock
 ) -> None:
-    PragmaChecker(config, fix_errors=True).check()
+    result = PragmaChecker(config, fix_errors=True).check()
+    assert result == 1
     assert mock_file_contents().write.mock_calls == [
         call("#pragma once\n"),
         call("\n"),

--- a/tests/ut/scargo_check/ut_scargo_check.py
+++ b/tests/ut/scargo_check/ut_scargo_check.py
@@ -21,12 +21,16 @@ CHECKERS = [
 
 @pytest.fixture
 def mock_checkers(mocker: MockerFixture) -> Dict[str, MagicMock]:
-    return {
+    checkers = {
         checker_class.check_name: mocker.patch(
             f"{scargo_check.__module__}.{checker_class.__name__}"
         )
         for checker_class in CHECKERS
     }
+    for name, checker in checkers.items():
+        checker.check_name = name
+        checker().check.return_value = 0
+    return checkers
 
 
 @pytest.fixture

--- a/tests/ut/scargo_check/ut_todo_checker.py
+++ b/tests/ut/scargo_check/ut_todo_checker.py
@@ -38,7 +38,8 @@ def test_check_todo_pass(
     config: Config,
     mock_find_files: MagicMock,
 ) -> None:
-    TodoChecker(config).check()
+    result = TodoChecker(config).check()
+    assert result == 0
     assert all(
         level not in ("WARNING", "ERROR") for level, msg in get_log_data(caplog.records)
     )
@@ -55,9 +56,8 @@ def test_check_todo_fail(
     config: Config,
     mock_find_files: MagicMock,
 ) -> None:
-    with pytest.raises(SystemExit) as wrapped_exception:
-        TodoChecker(config).check()
-    assert wrapped_exception.value.code == 1
+    result = TodoChecker(config).check()
+    assert result == 1
     assert ("WARNING", "Found TODO in foo/bar.hpp at line 1") in get_log_data(
         caplog.records
     )


### PR DESCRIPTION
#99

* make log messages clearer and more consistent
* run all checks even if some of them fail; if so, print a summary and exit with an error status