### PR TITLE
Build tests with conan using debug settings

### DIFF
--- a/scargo/commands/test.py
+++ b/scargo/commands/test.py
@@ -42,15 +42,19 @@ def scargo_test(verbose: bool, profile: str = "Debug") -> None:
     try:
         # Run CMake and build tests.
         subprocess.check_call(
-            ["conan", "install", tests_src_dir, "-if", test_build_dir],
+            [
+                "conan",
+                "install",
+                tests_src_dir,
+                "-if",
+                test_build_dir,
+                f"-sbuild_type={profile}",
+            ],
             cwd=project_dir,
         )
         subprocess.check_call(
-            ["cmake", f"-DCMAKE_BUILD_TYPE={profile}", tests_src_dir],
-            cwd=test_build_dir,
-        )
-        subprocess.check_call(
-            "cmake --build . --parallel", shell=True, cwd=test_build_dir
+            ["conan", "build", tests_src_dir, "-bf", test_build_dir],
+            cwd=project_dir,
         )
     except subprocess.CalledProcessError:
         logger.error("Failed to build tests.")

--- a/tests/ut/ut_scargo_test.py
+++ b/tests/ut/ut_scargo_test.py
@@ -35,9 +35,8 @@ def test_scargo_test_no_cmake_file(  # type: ignore[no-any-unimported]
 def test_scargo_test(  # type: ignore[no-any-unimported]
     fp: FakeProcess, fs: FakeFilesystem, mock_prepare_config: MagicMock
 ) -> None:
-    fp.register("conan install tests -if build/tests")
-    fp.register("cmake -DCMAKE_BUILD_TYPE=Debug tests")
-    fp.register("cmake --build . --parallel")
+    fp.register("conan install tests -if build/tests -sbuild_type=Debug")
+    fp.register("conan build tests -bf build/tests")
     fp.register("ctest")
     fp.register("gcovr -r ut . -f src --html ut-coverage.html")
     os.mkdir("tests")
@@ -50,11 +49,11 @@ def test_scargo_test(  # type: ignore[no-any-unimported]
         Path("tests"),
         "-if",
         Path("build/tests"),
+        "-sbuild_type=Debug",
     ]
-    assert fp.calls[1] == ["cmake", "-DCMAKE_BUILD_TYPE=Debug", Path("tests")]
-    assert fp.calls[2] == "cmake --build . --parallel"
-    assert fp.calls[3] == ["ctest"]
-    assert fp.calls[4] == [
+    assert fp.calls[1] == ["conan", "build", Path("tests"), "-bf", Path("build/tests")]
+    assert fp.calls[2] == ["ctest"]
+    assert fp.calls[3] == [
         "gcovr",
         "-r",
         "ut",


### PR DESCRIPTION
Followup to #169, fixes #138
This reverts to using conan in order not to break test dependencies. Tests are build by default with debug symbols and no optimization.