### PR TITLE
port flag behavior updated

### DIFF
--- a/scargo/commands/flash.py
+++ b/scargo/commands/flash.py
@@ -55,22 +55,26 @@ def flash_esp32(
             command = ["parttool.py"]
             if port:
                 command.append(f"--port={port}")
-            command.extend[
-                "write_partition",
-                "--partition-name=ota_0",
-                f"--input={app_path}",
-            ]
+            command.extend(
+                [
+                    "write_partition",
+                    "--partition-name=ota_0",
+                    f"--input={app_path}",
+                ]
+            )
             subprocess.check_call(command, cwd=project_path)
         elif fs:
             fs_path = config.project_root / "build" / "spiffs.bin"
             command = ["parttool.py"]
             if port:
                 command.append(f"--port={port}")
-            command.extend[
-                "write_partition",
-                "--partition-name=spiffs",
-                f"--input={fs_path}",
-            ]
+            command.extend(
+                [
+                    "write_partition",
+                    "--partition-name=spiffs",
+                    f"--input={fs_path}",
+                ]
+            )
             subprocess.check_call(command, cwd=project_path)
         else:
             command = ["esptool.py"]

--- a/scargo/commands/flash.py
+++ b/scargo/commands/flash.py
@@ -52,30 +52,29 @@ def flash_esp32(
         if app:
             app_name = config.project.name
             app_path = out_dir / f"{app_name}.bin"
-            command = [
-                "parttool.py",
-                "write_partition",
-                "--partition-name=ota_0",
-                f"--input={app_path}",
-            ]
+            command = ["parttool.py"]
             if port:
                 command.append(f"--port={port}")
+            command.extend["write_partition",
+                           "--partition-name=ota_0",
+                           f"--input={app_path}",
+                           ]
             subprocess.check_call(command, cwd=project_path)
         elif fs:
             fs_path = config.project_root / "build" / "spiffs.bin"
-            command = [
-                "parttool.py",
-                "write_partition",
-                "--partition-name=spiffs",
-                f"--input={fs_path}",
-            ]
+            command = ["parttool.py"]
             if port:
                 command.append(f"--port={port}")
+            command.extend["write_partition",
+                           "--partition-name=spiffs",
+                           f"--input={fs_path}",
+                           ]
             subprocess.check_call(command, cwd=project_path)
         else:
-            command = ["esptool.py", "--chip", target.id, "write_flash", "@flash_args"]
+            command = ["esptool.py"]
             if port:
                 command.append(f"--port={port}")
+            command.extend(["--chip", target.id, "write_flash", "@flash_args"])
             subprocess.check_call(command, cwd=out_dir)
     except subprocess.CalledProcessError:
         logger.error("%s fail", command)

--- a/scargo/commands/flash.py
+++ b/scargo/commands/flash.py
@@ -110,7 +110,11 @@ def flash_stm32(
         logger.info("Define flash-start in scargo.toml under stm32 section")
     else:
         if erase_memory:
-            subprocess.check_call(["st-flash", "erase"])
+            command = ["st-flash"]
+            if port:
+                command.append(f"--serial={port}")
+            command.append("erase")
+            subprocess.check_call(command)
 
         command = ["st-flash", "--reset"]
         if port:

--- a/scargo/commands/flash.py
+++ b/scargo/commands/flash.py
@@ -55,20 +55,22 @@ def flash_esp32(
             command = ["parttool.py"]
             if port:
                 command.append(f"--port={port}")
-            command.extend["write_partition",
-                           "--partition-name=ota_0",
-                           f"--input={app_path}",
-                           ]
+            command.extend[
+                "write_partition",
+                "--partition-name=ota_0",
+                f"--input={app_path}",
+            ]
             subprocess.check_call(command, cwd=project_path)
         elif fs:
             fs_path = config.project_root / "build" / "spiffs.bin"
             command = ["parttool.py"]
             if port:
                 command.append(f"--port={port}")
-            command.extend["write_partition",
-                           "--partition-name=spiffs",
-                           f"--input={fs_path}",
-                           ]
+            command.extend[
+                "write_partition",
+                "--partition-name=spiffs",
+                f"--input={fs_path}",
+            ]
             subprocess.check_call(command, cwd=project_path)
         else:
             command = ["esptool.py"]

--- a/scargo/commands/flash.py
+++ b/scargo/commands/flash.py
@@ -23,7 +23,7 @@ def scargo_flash(
     config = prepare_config()
     target = config.project.target
 
-    if port and (target.family != "esp32" or target.family != "stm32"):
+    if port and (target.family != "esp32" and target.family != "stm32"):
         logger.error("--port option is only supported for esp32 and stm32 projects.")
         sys.exit(1)
     if not erase_memory and target.family != "stm32":
@@ -62,7 +62,7 @@ def flash_esp32(
                     f"--input={app_path}",
                 ]
             )
-            subprocess.check_call(command, cwd=project_path)
+            subprocess.check_call(command)
         elif fs:
             fs_path = config.project_root / "build" / "spiffs.bin"
             command = ["parttool.py"]
@@ -75,7 +75,7 @@ def flash_esp32(
                     f"--input={fs_path}",
                 ]
             )
-            subprocess.check_call(command, cwd=project_path)
+            subprocess.check_call(command)
         else:
             command = ["esptool.py"]
             if port:
@@ -120,4 +120,4 @@ def flash_stm32(
         if port:
             command.append(f"--serial={port}")
         command.extend(["write", str(bin_path), flash_start])
-        subprocess.check_call(command, cwd=project_path)
+        subprocess.check_call(command)


### PR DESCRIPTION
#52

Update port command to work with stm32 and esp32:
stm32:
stlinkv2 command line: ./st-flash [--debug] [--reset] [--serial <serial>] [--format <format>] [--flash=<fsize>] {read|write} <path> <addr> <size>
stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] erase


esp32:
Proposed change
the port should be added in the following way to work with esptool:
esptool.py --chip esp32 --port=/dev/ttyUSB0 write_flash --flash_mode dio --flash_freq 80m --flash_size 4MB 0x1000 bootloader/bootloader.bin 0x10000 esp32-ihub-scargo.bin 0x8000 partition_table/partition-table.bin 0xd000 ota_data_initial.bin
esptool.py v3.3.2
Serial port /dev/ttyUSB0
Connecting.......
Chip is ESP32-D0WD-V3 (revision 3)

Example of the problem:
aak@da3c6982b4db:/workspace$ scargo flash --fs --port /dev/ttyUSB0
usage: ESP-IDF Partitions Tool [-h] [--quiet] [--esptool-args ESPTOOL_ARGS [ESPTOOL_ARGS ...]] [--esptool-write-args ESPTOOL_WRITE_ARGS [ESPTOOL_WRITE_ARGS ...]]
[--esptool-read-args ESPTOOL_READ_ARGS [ESPTOOL_READ_ARGS ...]] [--esptool-erase-args ESPTOOL_ERASE_ARGS [ESPTOOL_ERASE_ARGS ...]] [--port PORT] [--baud BAUD]
[--partition-table-offset PARTITION_TABLE_OFFSET] [--partition-table-file PARTITION_TABLE_FILE]
{read_partition,write_partition,erase_partition,get_partition_info} ...
ESP-IDF Partitions Tool: error: unrecognized arguments: --port=/dev/ttyUSB0
scargo ERROR: ['parttool.py', 'write_partition', '--partition-name=spiffs', '--input=/workspace/build/spiffs.bin', '--port=/dev/ttyUSB0'] fail