### PR TITLE
create CMakeLists.txt for ESP32 with library option

### DIFF
--- a/scargo/file_generators/templates/cpp/cmake-src-esp32.j2
+++ b/scargo/file_generators/templates/cpp/cmake-src-esp32.j2
@@ -2,3 +2,10 @@
 idf_component_register(SRCS "{{config.project.bin_name|lower}}.cpp"
                     INCLUDE_DIRS "")
 {% endif %}
+{% if config.project.lib_name %}
+add_library({{ config.project.lib_name|lower }} STATIC ${CMAKE_CURRENT_SOURCE_DIR}/{{ config.project.lib_name|lower }}.cpp)
+target_include_directories({{ config.project.lib_name|lower }} PRIVATE ${CONAN_INCLUDES})
+configure_file({{ config.project.lib_name|lower }}.h ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/{{ config.project.lib_name|lower }}.h COPYONLY)
+
+target_link_libraries({{ config.project.lib_name|lower }} ${CONAN_LIBS})
+{% endif %}


### PR DESCRIPTION
Content of the CMakeLists.txt in the main directory looks like:

```
add_library(esp32_lib_test STATIC ${CMAKE_CURRENT_SOURCE_DIR}/esp32_lib_test.cpp)
target_include_directories(esp32_lib_test PRIVATE ${CONAN_INCLUDES})
configure_file(esp32_lib_test.h ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/esp32_lib_test.h COPYONLY)

target_link_libraries(esp32_lib_test ${CONAN_LIBS})
```
