### PR TITLE
docker compose v2 support

### DIFF
--- a/scargo/commands/docker.py
+++ b/scargo/commands/docker.py
@@ -3,6 +3,7 @@
 # #
 
 """Handle docker for project"""
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -32,10 +33,11 @@ def scargo_docker_build(
         project_root = get_scargo_config_or_exit().project_root
     docker_path = _get_docker_path(project_root)
 
+    cmd = get_docker_command()
+    cmd.extend(["build", *docker_opts])
+
     try:
-        subprocess.run(
-            ["docker-compose", "build", *docker_opts], cwd=docker_path, check=True
-        )
+        subprocess.run(cmd, cwd=docker_path, check=True)
         logger.info("Initialize docker environment.")
     except subprocess.CalledProcessError:
         logger.error("Build docker fail.")
@@ -59,12 +61,14 @@ def scargo_docker_run(
     docker_path = _get_docker_path(config.project_root)
     project_config_name = config.project.name
 
-    cmd = [
-        "docker-compose",
-        "run",
-        *docker_opts,
-        f"{project_config_name}_dev",
-    ]
+    cmd = get_docker_command()
+    cmd.extend(
+        [
+            "run",
+            *docker_opts,
+            f"{project_config_name}_dev",
+        ]
+    )
     if command:
         cmd.extend(["bash", "-c", command])
 
@@ -115,3 +119,22 @@ def _get_docker_path(project_path: Path) -> Path:
         logger.error("Cannot used docker command inside the docker container.")
         sys.exit(1)
     return Path(project_path, ".devcontainer")
+
+
+def get_docker_command() -> List[str]:
+    """Get docker command
+
+    Returns:
+        List[str]: _description_
+    """
+    command = ["docker-compose"]
+    # Check if docker-compose or docker compose is available
+    if shutil.which("docker-compose"):
+        command = ["docker-compose"]
+    elif shutil.which("docker"):
+        command = ["docker", "compose"]
+    else:
+        logger.error("Neither docker-compose nor docker compose are available.")
+        sys.exit(1)
+
+    return command

--- a/scargo/commands/docker.py
+++ b/scargo/commands/docker.py
@@ -33,7 +33,7 @@ def scargo_docker_build(
         project_root = get_scargo_config_or_exit().project_root
     docker_path = _get_docker_path(project_root)
 
-    cmd = get_docker_command()
+    cmd = get_docker_compose_command()
     cmd.extend(["build", *docker_opts])
 
     try:
@@ -61,7 +61,7 @@ def scargo_docker_run(
     docker_path = _get_docker_path(config.project_root)
     project_config_name = config.project.name
 
-    cmd = get_docker_command()
+    cmd = get_docker_compose_command()
     cmd.extend(
         [
             "run",
@@ -121,7 +121,7 @@ def _get_docker_path(project_path: Path) -> Path:
     return Path(project_path, ".devcontainer")
 
 
-def get_docker_command() -> List[str]:
+def get_docker_compose_command() -> List[str]:
     """Get docker command
 
     Returns:

--- a/scargo/commands/update.py
+++ b/scargo/commands/update.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scargo.commands.docker import scargo_docker_build
+from scargo.commands.docker import get_docker_command, scargo_docker_build
 from scargo.config_utils import add_version_to_scargo_lock, get_scargo_config_or_exit
 from scargo.file_generators.cicd_gen import generate_cicd
 from scargo.file_generators.cmake_gen import generate_cmake
@@ -108,8 +108,10 @@ def scargo_update(config_file_path: Path) -> None:
 def pull_docker_image(docker_path: Path) -> bool:
     logger.info("Pulling the image from docker registry...")
     try:
+        cmd = get_docker_command()
+        cmd.extend(["pull"])
         result = subprocess.run(
-            ["docker-compose", "pull"],
+            cmd,
             cwd=docker_path,
             stderr=subprocess.PIPE,
             check=True,

--- a/scargo/commands/update.py
+++ b/scargo/commands/update.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scargo.commands.docker import get_docker_command, scargo_docker_build
+from scargo.commands.docker import get_docker_compose_command, scargo_docker_build
 from scargo.config_utils import add_version_to_scargo_lock, get_scargo_config_or_exit
 from scargo.file_generators.cicd_gen import generate_cicd
 from scargo.file_generators.cmake_gen import generate_cmake
@@ -108,7 +108,7 @@ def scargo_update(config_file_path: Path) -> None:
 def pull_docker_image(docker_path: Path) -> bool:
     logger.info("Pulling the image from docker registry...")
     try:
-        cmd = get_docker_command()
+        cmd = get_docker_compose_command()
         cmd.extend(["pull"])
         result = subprocess.run(
             cmd,

--- a/tests/ut/ut_scargo_docker.py
+++ b/tests/ut/ut_scargo_docker.py
@@ -85,14 +85,16 @@ def test_docker_run_with_command(
     service_name = f"{scargo_docker_test_setup.project.name}_dev"
     called_subprocess_cmd = get_docker_command()
 
-    called_subprocess_cmd.extend([
-        "run",
-        rm,
-        service_name,
-        "bash",
-        "-c",
-        command,
-    ])
+    called_subprocess_cmd.extend(
+        [
+            "run",
+            rm,
+            service_name,
+            "bash",
+            "-c",
+            command,
+        ]
+    )
     assert mock_subprocess_run.call_args.args[0] == called_subprocess_cmd
 
 

--- a/tests/ut/ut_scargo_docker.py
+++ b/tests/ut/ut_scargo_docker.py
@@ -7,7 +7,7 @@ import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 from scargo.commands.docker import (
-    get_docker_command,
+    get_docker_compose_command,
     scargo_docker_build,
     scargo_docker_exec,
     scargo_docker_run,
@@ -52,7 +52,7 @@ def test_docker_build(
     scargo_docker_test_setup: Config,
 ) -> None:
     scargo_docker_build(command_args)
-    called_subprocess_cmd = get_docker_command()
+    called_subprocess_cmd = get_docker_compose_command()
     called_subprocess_cmd.extend(["build", *command_args])
     assert mock_subprocess_run.call_args.args[0] == called_subprocess_cmd
 
@@ -69,7 +69,7 @@ def test_docker_run(
     scargo_docker_run(command_args)
 
     service_name = f"{scargo_docker_test_setup.project.name}_dev"
-    called_subprocess_cmd = get_docker_command()
+    called_subprocess_cmd = get_docker_compose_command()
     called_subprocess_cmd.extend(["run", *command_args, service_name])
     assert mock_subprocess_run.call_args.args[0] == called_subprocess_cmd
 
@@ -83,7 +83,7 @@ def test_docker_run_with_command(
     scargo_docker_run(docker_opts=[rm], command=command)
 
     service_name = f"{scargo_docker_test_setup.project.name}_dev"
-    called_subprocess_cmd = get_docker_command()
+    called_subprocess_cmd = get_docker_compose_command()
 
     called_subprocess_cmd.extend(
         [

--- a/tests/ut/ut_scargo_docker.py
+++ b/tests/ut/ut_scargo_docker.py
@@ -7,6 +7,7 @@ import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 from scargo.commands.docker import (
+    get_docker_command,
     scargo_docker_build,
     scargo_docker_exec,
     scargo_docker_run,
@@ -51,8 +52,8 @@ def test_docker_build(
     scargo_docker_test_setup: Config,
 ) -> None:
     scargo_docker_build(command_args)
-
-    called_subprocess_cmd = ["docker-compose", "build", *command_args]
+    called_subprocess_cmd = get_docker_command()
+    called_subprocess_cmd.extend(["build", *command_args])
     assert mock_subprocess_run.call_args.args[0] == called_subprocess_cmd
 
 
@@ -68,7 +69,8 @@ def test_docker_run(
     scargo_docker_run(command_args)
 
     service_name = f"{scargo_docker_test_setup.project.name}_dev"
-    called_subprocess_cmd = ["docker-compose", "run", *command_args, service_name]
+    called_subprocess_cmd = get_docker_command()
+    called_subprocess_cmd.extend(["run", *command_args, service_name])
     assert mock_subprocess_run.call_args.args[0] == called_subprocess_cmd
 
 
@@ -81,15 +83,16 @@ def test_docker_run_with_command(
     scargo_docker_run(docker_opts=[rm], command=command)
 
     service_name = f"{scargo_docker_test_setup.project.name}_dev"
-    called_subprocess_cmd = [
-        "docker-compose",
+    called_subprocess_cmd = get_docker_command()
+
+    called_subprocess_cmd.extend([
         "run",
         rm,
         service_name,
         "bash",
         "-c",
         command,
-    ]
+    ])
     assert mock_subprocess_run.call_args.args[0] == called_subprocess_cmd
 
 

--- a/tests/ut/ut_scargo_update.py
+++ b/tests/ut/ut_scargo_update.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from pytest_subprocess import FakeProcess
+from scargo.commands.docker import get_docker_command
 
 from scargo.commands.new import scargo_new
 from scargo.commands.update import scargo_update
@@ -47,7 +48,9 @@ def test_update_project_content_with_docker(tmp_path: Path, fp: FakeProcess) -> 
     project_name = "test_project_with_docker"
     scargo_new(project_name, None, None, TARGET_X86, True, False)
     os.chdir(project_name)
-    fp.register("docker-compose pull")
+    called_subprocess_cmd = get_docker_command()
+    called_subprocess_cmd.extend(["pull"])
+    fp.register(called_subprocess_cmd)
     scargo_update(Path("scargo.toml"))
     for path in Path().iterdir():
         assert path.name in EXPECTED_FILES_AND_DIRS
@@ -60,9 +63,13 @@ def test_update_project_content_with_docker__build(
     project_name = "test_project_with_docker"
     scargo_new(project_name, None, None, TARGET_X86, True, False)
     os.chdir(project_name)
-    fp.register("docker-compose pull", returncode=1)
-    fp.register("docker-compose build")
+    cmd_pull = get_docker_command()
+    cmd_pull.extend(["pull"])
+    fp.register(cmd_pull, returncode=1)
+    cmd_build = get_docker_command()
+    cmd_build.extend(["build"])
+    fp.register(cmd_build)
     scargo_update(Path("scargo.toml"))
-    assert fp.call_count("docker-compose build") == 1
+    assert fp.call_count(cmd_build) == 1
     for path in Path().iterdir():
         assert path.name in EXPECTED_FILES_AND_DIRS

--- a/tests/ut/ut_scargo_update.py
+++ b/tests/ut/ut_scargo_update.py
@@ -2,8 +2,8 @@ import os
 from pathlib import Path
 
 from pytest_subprocess import FakeProcess
-from scargo.commands.docker import get_docker_command
 
+from scargo.commands.docker import get_docker_command
 from scargo.commands.new import scargo_new
 from scargo.commands.update import scargo_update
 from scargo.config import Target

--- a/tests/ut/ut_scargo_update.py
+++ b/tests/ut/ut_scargo_update.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from pytest_subprocess import FakeProcess
 
-from scargo.commands.docker import get_docker_command
+from scargo.commands.docker import get_docker_compose_command
 from scargo.commands.new import scargo_new
 from scargo.commands.update import scargo_update
 from scargo.config import Target
@@ -48,7 +48,7 @@ def test_update_project_content_with_docker(tmp_path: Path, fp: FakeProcess) -> 
     project_name = "test_project_with_docker"
     scargo_new(project_name, None, None, TARGET_X86, True, False)
     os.chdir(project_name)
-    called_subprocess_cmd = get_docker_command()
+    called_subprocess_cmd = get_docker_compose_command()
     called_subprocess_cmd.extend(["pull"])
     fp.register(called_subprocess_cmd)
     scargo_update(Path("scargo.toml"))
@@ -63,10 +63,10 @@ def test_update_project_content_with_docker__build(
     project_name = "test_project_with_docker"
     scargo_new(project_name, None, None, TARGET_X86, True, False)
     os.chdir(project_name)
-    cmd_pull = get_docker_command()
+    cmd_pull = get_docker_compose_command()
     cmd_pull.extend(["pull"])
     fp.register(cmd_pull, returncode=1)
-    cmd_build = get_docker_command()
+    cmd_build = get_docker_compose_command()
     cmd_build.extend(["build"])
     fp.register(cmd_build)
     scargo_update(Path("scargo.toml"))


### PR DESCRIPTION
There was no support for docker compose command (only for docker-compose where version was >=1.29).
The support for docker compose command was added and test was adjust. docker-compose can still be used, and scargo will automatically check which command is available on the pc