### PR TITLE
Remove BaltimoreCyberTrustRoot cert from cert gen

### DIFF
--- a/scargo/certs/generateAllCertificates.sh
+++ b/scargo/certs/generateAllCertificates.sh
@@ -95,10 +95,10 @@ rm -f ${CA_PEM}
 if [ -f "$DIGIROOT_CERT" ]; then
     echo "$DIGIROOT_CERT already exists."
 else
-    wget https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -O ${OUTPUT_DIR}/digiroot.pem
+    wget https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -O ${DIGIROOT_CERT}
     if [ $? -ne 0 ]; then
         echo -e "${RED} Failed to download Digiroot certificate" >&2
-        rm ${OUTPUT_DIR}/digiroot.pem
+        rm ${DIGIROOT_CERT}
         exit 1
     fi
 fi

--- a/scargo/certs/generateAllCertificates.sh
+++ b/scargo/certs/generateAllCertificates.sh
@@ -90,7 +90,7 @@ mkdir -p ${OUTPUT_DIR}
 DIGIROOT_CERT=${OUTPUT_DIR}/digiroot.pem
 CA_PEM=${OUTPUT_DIR}/ca.pem
 
-rm -f ${OUTPUT_DIR}/ca.pem
+rm -f ${CA_PEM}
 
 if [ -f "$DIGIROOT_CERT" ]; then
     echo "$DIGIROOT_CERT already exists."
@@ -103,7 +103,7 @@ else
     fi
 fi
 
-cp ${OUTPUT_DIR}/digiroot.pem ${OUTPUT_DIR}/ca.pem
+cp ${DIGIROOT_CERT} ${CA_PEM}
 
 if [ ${MODE} == "Device-certificate" ]; then
     #Generate only device cert

--- a/scargo/certs/generateAllCertificates.sh
+++ b/scargo/certs/generateAllCertificates.sh
@@ -87,22 +87,10 @@ if [ -z "$DEVICE_NAME" ]
 mkdir -p ${OUTPUT_DIR}
 
 #Download CA certificate for IoT Hub
-BALTIMORE_CERT=${OUTPUT_DIR}/baltimore.pem
 DIGIROOT_CERT=${OUTPUT_DIR}/digiroot.pem
 CA_PEM=${OUTPUT_DIR}/ca.pem
 
 rm -f ${OUTPUT_DIR}/ca.pem
-
-if [ -f "$BALTIMORE_CERT" ]; then
-    echo "$BALTIMORE_CERT already exists."
-else
-    wget https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem -O ${OUTPUT_DIR}/baltimore.pem
-    if [ $? -ne 0 ]; then
-        echo -e "${RED} Failed to download Baltimore certificate" >&2
-        rm ${OUTPUT_DIR}/baltimore.pem
-        exit 1
-    fi
-fi
 
 if [ -f "$DIGIROOT_CERT" ]; then
     echo "$DIGIROOT_CERT already exists."
@@ -115,10 +103,7 @@ else
     fi
 fi
 
-cat ${OUTPUT_DIR}/baltimore.pem >> ${OUTPUT_DIR}/ca_temp.pem
-cat ${OUTPUT_DIR}/digiroot.pem >> ${OUTPUT_DIR}/ca_temp.pem
-grep . ${OUTPUT_DIR}/ca_temp.pem > ${OUTPUT_DIR}/ca.pem
-rm -f ${OUTPUT_DIR}/ca_temp.pem
+cat ${OUTPUT_DIR}/digiroot.pem >> ${OUTPUT_DIR}/ca.pem
 
 if [ ${MODE} == "Device-certificate" ]; then
     #Generate only device cert

--- a/scargo/certs/generateAllCertificates.sh
+++ b/scargo/certs/generateAllCertificates.sh
@@ -103,7 +103,7 @@ else
     fi
 fi
 
-cat ${OUTPUT_DIR}/digiroot.pem >> ${OUTPUT_DIR}/ca.pem
+cp ${OUTPUT_DIR}/digiroot.pem ${OUTPUT_DIR}/ca.pem
 
 if [ ${MODE} == "Device-certificate" ]; then
     #Generate only device cert


### PR DESCRIPTION
Regarding https://learn.microsoft.com/en-gb/azure/iot-hub/migrate-tls-certificate?tabs=portal Baltimore CA certificate is deprecated now, thus there is no need to generate it