### PR TITLE
Handle non standard profiles

### DIFF
--- a/scargo/commands/publish.py
+++ b/scargo/commands/publish.py
@@ -27,7 +27,6 @@ def scargo_publish(repo: str, profile: str = "Release") -> None:
     project_path = config.project_root
     project_config = config.project
     project_name = project_config.name
-    version = project_config.version
 
     conan_clean_remote()
     conan_add_remote(project_path, config)

--- a/scargo/config.py
+++ b/scargo/config.py
@@ -156,6 +156,9 @@ ScargoTargets = Enum(  # type: ignore[misc]
 class ProfileConfig(BaseModel, extra=Extra.allow):
     cflags: Optional[str]
     cxxflags: Optional[str]
+    cc: Optional[str] = None
+    cxx: Optional[str] = None
+    cmake_build_type: Optional[str] = Field("Debug", alias="cmake-build-type")
 
     @property
     def extras(self) -> Dict[str, Any]:

--- a/scargo/file_generators/conan_gen.py
+++ b/scargo/file_generators/conan_gen.py
@@ -2,6 +2,8 @@
 # @copyright Copyright (C) 2023 SpyroSoft Solutions S.A. All rights reserved.
 # #
 
+from typing import List
+
 from scargo.config import Config
 from scargo.file_generators.base_gen import create_file_from_template
 
@@ -22,19 +24,26 @@ def generate_conanfile(config: Config) -> None:
 
 
 def generate_conanprofile(config: Config) -> None:
-    profiles = list(config.profiles.keys())
+    profiles = config.profiles.keys()
+    standard_profiles: List[str] = ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"]
+
     if config.project.target.family == "stm32":
         create_file_from_template(
             "conan/stm32_gcc_toolchain_wrapper.cmake.j2",
-            f".conan/profiles/stm32_gcc_toolchain_wrapper.cmake",
+            ".conan/profiles/stm32_gcc_toolchain_wrapper.cmake",
             template_params={},
             config=config,
         )
+
     for profile in profiles:
         create_file_from_template(
             "conan/profile.j2",
             f".conan/profiles/{config.project.target.family}_{profile}",
-            template_params={"config": config, "profile": profile},
+            template_params={
+                "config": config,
+                "profile": profile,
+                "standard_profiles": standard_profiles,
+            },
             config=config,
         )
 

--- a/scargo/file_generators/templates/conan/profile.j2
+++ b/scargo/file_generators/templates/conan/profile.j2
@@ -1,13 +1,25 @@
 [env]
-{% if config.project.target.family == "stm32" %}
-CC=/opt/gcc-arm-none-eabi/bin/arm-none-eabi-gcc
-CXX=/opt/gcc-arm-none-eabi/bin/arm-none-eabi-g++
-{% elif config.project.target.family == "esp32" %}
-CC=$ENV{IDF_PATH}/tools/xtensa-esp32-elf/esp-2021r2-patch5-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc
-CXX=$ENV{IDF_PATH}/tools/xtensa-esp32-elf/esp-2021r2-patch5-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-g++
+{% if config.profiles[profile].cc %}
+CC={{ config.profiles[profile].cc }}
 {% else %}
+    {% if config.project.target.family == "stm32" %}
+CC=/opt/gcc-arm-none-eabi/bin/arm-none-eabi-gcc
+    {% elif config.project.target.family == "esp32" %}
+CC=$ENV{IDF_PATH}/tools/xtensa-esp32-elf/esp-2021r2-patch5-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc
+    {% else %}
 CC=gcc
-CC=g++
+    {% endif %}
+{% endif %}
+{% if config.profiles[profile].cxx %}
+CXX={{ config.profiles[profile].cxx }}
+{% else %}
+    {% if config.project.target.family == "stm32" %}
+CXX=/opt/gcc-arm-none-eabi/bin/arm-none-eabi-g++
+    {% elif config.project.target.family == "esp32" %}
+CXX=$ENV{IDF_PATH}/tools/xtensa-esp32-elf/esp-2021r2-patch5-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-g++
+    {% else %}
+CXX=g++
+    {% endif %}
 {% endif %}
 
 {% if config.project.target.family == "stm32" %}
@@ -25,7 +37,10 @@ compiler.cppstd={{ config.project.cxxstandard }}
 os_build=Linux
 arch_build=x86_64
 
-build_type={{profile}}
+{# TODO: [kta] Here there is a code smell due to satisfy backwards-compatibility. Change in scargo 2.0 to: #}
+{# cmake_build_type = {{ config.profiles[profile].cmake_build_type }} #}
+{# This will enforce definition of cmake_build_type in scargo.toml [profile.X] section #}
+build_type={{ profile if (profile in standard_profiles) else config.profiles[profile].cmake_build_type }}
 
 {% if config.project.target.family == "stm32" %}
 os=baremetal
@@ -47,7 +62,6 @@ arch=xtensalx7
 {% elif config.project.target.family == "x86" %}
 arch=x86_64
 {% endif %}
-build_type={{profile}}
 
 [conf]
 tools.build:cflags=["{{ config.project.cflags if config.project.cflags}} {{config.profiles.get(profile).cflags if config.profiles.get(profile).cflags}}"]

--- a/tests/ut/ut_scargo_publish.py
+++ b/tests/ut/ut_scargo_publish.py
@@ -41,7 +41,6 @@ def config(monkeypatch: pytest.MonkeyPatch) -> Config:
 def test_publish(config: Config, fp: FakeProcess) -> None:
     # ARRANGE
     project_name = config.project.name
-    version = config.project.version
     conan_clean_cmd = "conan remote clean"
     conan_add_remote_1_cmd = ["conan", "remote", "add", REMOTE_REPO_NAME_1, EXAMPLE_URL]
     conan_add_remote_2_cmd = ["conan", "remote", "add", REMOTE_REPO_NAME_2, EXAMPLE_URL]
@@ -168,7 +167,6 @@ def test_create_package_fail(
 ) -> None:
     # ARRANGE
     project_name = config.project.name
-    version = config.project.version
     fp.register("conan remote clean")
     fp.register(["conan", "remote", "add", REMOTE_REPO_NAME_1, EXAMPLE_URL])
     fp.register(["conan", "remote", "add", REMOTE_REPO_NAME_2, EXAMPLE_URL])
@@ -216,7 +214,6 @@ def test_upload_package_fail(
 ) -> None:
     # ARRANGE
     project_name = config.project.name
-    version = config.project.version
     fp.register("conan remote clean")
     fp.register(["conan", "remote", "add", REMOTE_REPO_NAME_1, EXAMPLE_URL])
     fp.register(["conan", "remote", "add", REMOTE_REPO_NAME_2, EXAMPLE_URL])


### PR DESCRIPTION
When non-standard profile is used, scargo profile has errors. E.g. using Simu profile in esp32-ihub-scargo results in compilation errors. Aim of this PR is to resolve this issue