### PR TITLE
Update source code templates for .devcontainers with more default values

### DIFF
--- a/scargo/file_generators/templates/docker/Dockerfile-custom.j2
+++ b/scargo/file_generators/templates/docker/Dockerfile-custom.j2
@@ -1,4 +1,3 @@
 # user can add his docker code below which will be integrated with
 # main docker file and not overwritten by scargo update
-ENV DEBIAN_FRONTEND noninteractive
 

--- a/scargo/file_generators/templates/docker/Dockerfile-esp32.j2
+++ b/scargo/file_generators/templates/docker/Dockerfile-esp32.j2
@@ -10,8 +10,8 @@ ARG ESPRESSIF_IDF_PATH="/opt/esp-idf"
 ARG ESPRESSIF_IDF_REPO_URL="https://github.com/espressif/esp-idf.git"
 ARG ESPRESSIF_TOOLS_PATH="/root/.espressif"
 ARG RUN_CLANG_TIDY_SCRIPT_URL="https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-16.0.0/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py"
-ENV  IDF_TOOLS_PATH ${ESPRESSIF_IDF_PATH}
-ENV  IDF_PATH ${ESPRESSIF_IDF_PATH}
+ENV IDF_TOOLS_PATH ${ESPRESSIF_IDF_PATH}
+ENV IDF_PATH ${ESPRESSIF_IDF_PATH}
 
 WORKDIR /opt
 

--- a/scargo/file_generators/templates/docker/Dockerfile.j2
+++ b/scargo/file_generators/templates/docker/Dockerfile.j2
@@ -18,7 +18,7 @@ RUN apt update --fix-missing && \
 FROM base AS cpp
 
 RUN apt update --fix-missing && apt -y --no-install-recommends install cppcheck lib32z1 \
-    make cmake clang clang-format clang-tidy gcovr doxygen libcmocka0 libcmocka-dev gdb && \
+    make cmake clang clang-format clang-tidy gcovr doxygen libcmocka0 libcmocka-dev gdb  screen && \
     rm -rf /var/lib/apt/lists/*
 
 FROM cpp AS {{ project.target.family }}
@@ -35,9 +35,9 @@ ARG USER_PASSWORD=user
 ARG UID_NUMBER=1000
 ARG GID_NUMBER=1000
 ARG SSH_PORT=2000
+ARG CONAN_LOGIN_USERNAME=""
+ARG CONAN_PASSWORD=""
 
-ARG CONAN_LOGIN_USERNAME
-ARG CONAN_PASSWORD
 ENV CONAN_LOGIN_USERNAME=${CONAN_LOGIN_USERNAME}
 ENV CONAN_PASSWORD=${CONAN_PASSWORD}
 

--- a/scargo/file_generators/templates/docker/devcontainer.json.j2
+++ b/scargo/file_generators/templates/docker/devcontainer.json.j2
@@ -1,6 +1,33 @@
 {
-  "name": "{{ project.name }}_dev",
-  "dockerComposeFile": "docker-compose.yaml",
-  "service": "{{ project.name }}_dev",
-  "workspaceFolder": "/workspace"
+	"name": "{{ project.name }}-dev",
+	"dockerComposeFile": "docker-compose.yaml",
+	"service": "{{ project.name }}-dev",
+	"workspaceFolder": "/workspace",
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"files.insertFinalNewline": true,
+				"editor.formatOnSave": true,
+				"C_Cpp.default.includePath": [
+					"${workspaceFolder}/**"
+				],
+				"cSpell.words": [
+					"spyro",
+					"spyrosoft",
+					"cppcheck",
+					"lvgl",
+					"gpio",
+					"scargo",
+					"devcontainer",
+					"usbip"
+				]
+			},
+			"extensions": [
+				"xaver.clang-format",
+				"ms-vscode.cpptools-extension-pack",
+				"streetsidesoftware.code-spell-checker",
+				"ciarant.vscode-structurizr"
+			]
+		}
+	}
 }

--- a/scargo/file_generators/templates/docker/docker-compose.yaml.j2
+++ b/scargo/file_generators/templates/docker/docker-compose.yaml.j2
@@ -4,23 +4,21 @@
 ###
 version: '3.9'
 
-x-project_config: &project_config
-  USER_NAME: ${USER_NAME}
-  USER_PASSWORD: ${USER_PASSWORD}
-  GID_NUMBER: ${GID_NUMBER}
-  UID_NUMBER: ${UID_NUMBER}
-  DOCKER_IMAGE_ROOT: ${DOCKER_IMAGE_ROOT}
-  CONAN_LOGIN_USERNAME: ${CONAN_LOGIN_USERNAME}
-  CONAN_PASSWORD: ${CONAN_PASSWORD}
-
 services:
-  {{ config.project.name }}_dev:
+  {{ config.project.name }}-dev:
     image: {{ config.project.docker_image_tag }}
     platform: linux/amd64
     build:
       context: .
+      # in case of missing .env file (eg. CI/CD) system will use default values
       args:
-        <<: *project_config
+        USER_NAME: ${USER_NAME:-user}
+        USER_PASSWORD: ${USER_PASSWORD:-user}
+        GID_NUMBER: ${GID_NUMBER:-1000}
+        UID_NUMBER: ${UID_NUMBER:-1000}
+        DOCKER_IMAGE_ROOT: ${DOCKER_IMAGE_ROOT:-ubuntu:20.04}
+        CONAN_LOGIN_USERNAME: ${CONAN_LOGIN_USERNAME:-""}
+        CONAN_PASSWORD: ${CONAN_PASSWORD:-""}
     privileged: true
     volumes:
       - ..:/workspace


### PR DESCRIPTION
In general, this is "enhancement for .devcontainers": 

Human readable changes:
1. fixed - Removing .env breaks local compilation of .devcontainer
2. fixed - If CI can't build the image locally, it breaks
3. fixed - Standalone docker image compilation was not possible.
4. fixed - Removed dead code in "user docker image tempalte".
5. added - screen application to container image as an easy to use low level serial port tool.
6. added - English dictionary plug-in for Visual Studio code, as well as some default "extra words".
7. added - plugin with - default c++/cmake support for visual studio code.
8. added - plugin with - automatic clang formatting capabilities (formats code before file save)

