### PR TITLE
Fix typing-extensions dependency error on esp32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "toml==0.10.2",
     "tomlkit==0.11.6",
     "typer==0.7.0",
+    "typing-extensions==4.6.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
PR is targeting this [issue](https://github.com/Spyro-Soft/scargo/issues/331)