### PR TITLE
352: Correct ESP32 conan profile template

### DIFF
--- a/scargo/file_generators/templates/conan/profile_esp32.j2
+++ b/scargo/file_generators/templates/conan/profile_esp32.j2
@@ -15,7 +15,7 @@ arch=xtensalx6
 build_type={{ config.profiles[profile].cmake_build_type }}
 
 [conf]
-tools.cmake.cmaketoolchain:toolchain_file=/opt/esp-idf/tools/cmake/toolchain-esp32.cmake
+tools.cmake.cmaketoolchain:user_toolchain=["/opt/esp-idf/tools/cmake/toolchain-esp32.cmake"]
 tools.cmake.cmaketoolchain:generator=Ninja
 
 [options]


### PR DESCRIPTION
The default cmake toolchain file from conan should not be overwritten but extended.
This can be done with the following option in "conf" section of the profile:
```
tools.cmake.cmaketoolchain:user_toolchain=["/opt/esp-idf/tools/cmake/toolchain-esp32.cmake"]
```
