### PR TITLE
Bump typer to 0.9.0

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -289,7 +289,7 @@ tomlkit==0.11.6
     # via
     #   pylint
     #   scargo (pyproject.toml)
-typer==0.7.0
+typer==0.9.0
     # via scargo (pyproject.toml)
 types-clang==0.14.3
     # via scargo (pyproject.toml)
@@ -305,6 +305,7 @@ typing-extensions==4.6.0
     #   mypy
     #   pydantic
     #   scargo (pyproject.toml)
+    #   typer
 unittest-xml-reporting==3.2.0
     # via scargo (pyproject.toml)
 urllib3==1.26.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "shellingham==1.5.0.post1",
     "toml==0.10.2",
     "tomlkit==0.11.6",
-    "typer==0.7.0",
+    "typer==0.9.0",
     "typing-extensions==4.6.0",
     "paramiko==3.3.1",
     "pyyaml==6.0",


### PR DESCRIPTION
Bump typer version because custom types have been introduced in newer version (will be needed for future features)