### PR TITLE
Add flag to build command to build all targets

### DIFF
--- a/docs/source/scargo/scargo-build.rst
+++ b/docs/source/scargo/scargo-build.rst
@@ -33,6 +33,14 @@ If this option is not used, then the default profile is Debug.
 
 Build project for specified target. Releavant only for multitarget projects.
 
+
+::
+
+-a, --all                      [default: False]
+
+Build project for all targets.
+
+
 ::
 
 -B, --base-dir DIRECTORY

--- a/scargo/cli.py
+++ b/scargo/cli.py
@@ -63,11 +63,12 @@ def build(
         help="Target device. Defaults to first one from toml if not specified.",
     ),
     base_dir: Optional[Path] = BASE_DIR_OPTION,
+    all_targets: bool = Option(False, "-a", "--all", help="Build all targets."),
 ) -> None:
     """Compile sources."""
     if base_dir:
         os.chdir(base_dir)
-    scargo_build(profile, target)
+    scargo_build(profile, target, all_targets)
 
 
 ###############################################################################

--- a/scargo/cli.py
+++ b/scargo/cli.py
@@ -62,8 +62,8 @@ def build(
         "--target",
         help="Target device. Defaults to first one from toml if not specified.",
     ),
-    base_dir: Optional[Path] = BASE_DIR_OPTION,
     all_targets: bool = Option(False, "-a", "--all", help="Build all targets."),
+    base_dir: Optional[Path] = BASE_DIR_OPTION,
 ) -> None:
     """Compile sources."""
     if base_dir:

--- a/scargo/commands/build.py
+++ b/scargo/commands/build.py
@@ -6,9 +6,9 @@
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
-from scargo.config import ScargoTarget
+from scargo.config import Config, ScargoTarget, Target
 from scargo.config_utils import get_target_or_default, prepare_config
 from scargo.file_generators.conan_gen import conan_add_default_profile_if_missing
 from scargo.logger import get_logger
@@ -17,76 +17,92 @@ from scargo.utils.conan_utils import conan_add_remote, conan_source
 logger = get_logger()
 
 
-def scargo_build(profile: str, target: Optional[ScargoTarget]) -> None:
+def scargo_build(
+    profile: str, target: Optional[ScargoTarget], all_targets: bool = False
+) -> None:
     """
     Build project exec file.
 
     :param str profile: Profile
+    :param target: Target to build
+    :param bool all_targets: Build all targets
     :return: None
     """
     config = prepare_config()
-    build_target = get_target_or_default(config, target)
-
     project_dir = config.project_root
-    if not project_dir:
-        logger.error("Current working directory is not part of scargo project.")
-        sys.exit(1)
 
     if not Path(project_dir, "CMakeLists.txt").exists():
         logger.error("File `CMakeLists.txt` does not exist.")
         logger.info("Did you run `scargo update`?")
         sys.exit(1)
 
-    logger.info(f"Running scargo build for {build_target.id} target")
     conan_add_default_profile_if_missing()
     conan_add_remote(project_dir, config)
     conan_source(project_dir)
 
-    build_dir = Path(project_dir, build_target.get_profile_build_dir(profile))
-    build_dir.mkdir(parents=True, exist_ok=True)
-    profile_name = build_target.get_conan_profile_name(profile)
+    if not all_targets:
+        _scargo_build_targets(config, profile, [get_target_or_default(config, target)])
+    else:
+        _scargo_build_targets(config, profile, config.project.target)
 
-    try:
-        subprocess.run(
-            [
-                "conan",
-                "install",
-                ".",
-                "-pr",
-                f"./config/conan/profiles/{profile_name}",
-                "-of",
-                build_dir,
-                "-b",
-                "missing",
-            ],
-            cwd=project_dir,
-            check=True,
-        )
-        subprocess.run(
-            [
-                "conan",
-                "build",
-                ".",
-                "-pr",
-                f"./config/conan/profiles/{profile_name}",
-                "-of",
-                build_dir,
-            ],
-            cwd=project_dir,
-            check=True,
-        )
 
-        get_logger().info("Copying artifacts...")
-        # This is a workaround so that different profiles can work together with conan
-        # Conan always calls CMake with '
-        subprocess.run(
-            f"cp -r -l -f {build_dir}/build/{config.profiles[profile].cmake_build_type}/* .",
-            cwd=build_dir,
-            shell=True,
-            check=True,
-        )
-        get_logger().info("Artifacts copied")
+def _scargo_build_targets(config: Config, profile: str, targets: List[Target]) -> None:
+    """
+    Build project exec file.
 
-    except subprocess.CalledProcessError:
-        logger.error("Scargo build failed")
-        sys.exit(1)
+    :param str profile: Profile for which to build
+    :param list targets: Targets to build
+    :return: None
+    """
+    project_dir = config.project_root
+    for build_target in targets:
+        logger.info("Building %s target", build_target.id)
+
+        build_dir = Path(project_dir, build_target.get_profile_build_dir(profile))
+        build_dir.mkdir(parents=True, exist_ok=True)
+        profile_name = build_target.get_conan_profile_name(profile)
+
+        try:
+            subprocess.run(
+                [
+                    "conan",
+                    "install",
+                    ".",
+                    "-pr",
+                    f"./config/conan/profiles/{profile_name}",
+                    "-of",
+                    build_dir,
+                    "-b",
+                    "missing",
+                ],
+                cwd=project_dir,
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "conan",
+                    "build",
+                    ".",
+                    "-pr",
+                    f"./config/conan/profiles/{profile_name}",
+                    "-of",
+                    build_dir,
+                ],
+                cwd=project_dir,
+                check=True,
+            )
+
+            logger.info("Copying artifacts...")
+            # This is a workaround so that different profiles can work together with conan
+            # Conan always calls CMake with '
+            subprocess.run(
+                f"cp -r -l -f {build_dir}/build/{config.profiles[profile].cmake_build_type}/* .",
+                cwd=build_dir,
+                shell=True,
+                check=True,
+            )
+            logger.info("Artifacts copied")
+
+        except subprocess.CalledProcessError:
+            logger.error("Scargo build target %s failed", build_target.id)
+            sys.exit(1)

--- a/tests/ut/data/scargo_test_multitarget.toml
+++ b/tests/ut/data/scargo_test_multitarget.toml
@@ -1,0 +1,123 @@
+[project]
+name = "all_targets"
+version = "0.1.0"
+description = "Project description."
+homepage-url = "www.hello-world.com"
+
+bin_name = "all_targets"
+target = ["atsam", "stm32", "x86", "esp32"]
+build-env = "docker"
+docker-file = ".devcontainer/Dockerfile-custom"
+docker-image-tag = "all_targets-dev:1.0"
+
+cxxstandard = "17"
+
+cflags   = "-Wall -Wextra"
+cxxflags = "-Wall -Wextra"
+
+in-repo-conan-cache = false
+
+[profile.Debug]
+cflags   = "-g"
+cxxflags = "-g"
+
+[profile.Release]
+cflags   = "-O3 -DNDEBUG"
+cxxflags = "-O3 -DNDEBUG"
+
+[profile.RelWithDebInfo]
+cflags   = "-O2 -g -DNDEBUG"
+cxxflags = "-O2 -g -DNDEBUG"
+
+[profile.MinSizeRel]
+cflags   = "-Os -DNDEBUG"
+cxxflags = "-Os -DNDEBUG"
+
+[check]
+exclude = []
+
+[check.pragma]
+exclude = []
+
+[check.copyright]
+description = '@copyright Copyright \(C\) \d{4} .* All rights reserved.'
+exclude = []
+
+[fix.copyright]
+description = '''
+/**
+ * @copyright Copyright (C) 2023 <Company-Name>. All rights reserved.
+ */
+'''
+
+[check.todo]
+keywords = ["tbd", "todo", "TODO", "fixme"]
+exclude = []
+
+[check.clang-format]
+exclude = []
+
+[check.clang-tidy]
+exclude = []
+
+[check.cyclomatic]
+exclude = []
+
+[tests]
+cc  = "gcc"
+cxx = "g++"
+
+cflags   = "-Wall -Wextra -Og --coverage -fkeep-inline-functions -fkeep-static-consts"
+cxxflags = "-Wall -Wextra -Og --coverage -fkeep-inline-functions -fkeep-static-consts"
+
+gcov-executable = "" # Empty string -> use default gcov executable
+
+# Underhood scargo use conan. All string valid for conan tool are valid here. eg "gtest/1.13.0"
+[dependencies]
+#general -> public conan dependencies of project they will be added to package info (eg. bianry dynamic linkage libary) they will be added also to scargo test.
+general = [
+]
+#build -> private conan dependencies usedn only during build process(eg. private static linkage library)
+build = [
+]
+#tool -> special conan "not library" dependencies like cmake/3.22.
+tool = [
+]
+#test-> conan dependencies used only for testing targets
+test = [
+    "gtest/1.13.0"
+]
+
+[conan.repo]
+#Passing conancenter here is not nessary as scargo adds it by default
+#Below example of private binary artifacts repository
+#my_artifactory = "https://my_artifactory/api/conan/conanlocal"
+
+[esp32]
+chip = "esp32"
+extra_component_dirs = ['src']
+partitions = [
+    "nvs,      data, nvs,     0x9000,  0x4000,",
+    "otadata,  data, ota,     0xd000,  0x2000,",
+    "phy_init, data, phy,     0xf000,  0x1000,",
+    "ota_0,    app,  ota_0,   0x10000, 0x180000,",
+    "ota_1,    app,  ota_1,   0x190000,0x180000,",
+    "spiffs,   data, spiffs,  0x310000,0x6000,",
+]
+
+[stm32]
+chip = "STM32L496AG"
+flash-start = 0x08000000
+
+[atsam]
+chip = "ATSAML10E16A"
+cpu = "cortex-m23"
+
+
+[scargo]
+console-log-level = "INFO"
+file-log-level = "WARNING"
+update-exclude = []
+
+[docker-compose]
+ports = []

--- a/tests/ut/ut_scargo_build.py
+++ b/tests/ut/ut_scargo_build.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -7,22 +8,131 @@ from pytest_mock import MockerFixture
 from pytest_subprocess import FakeProcess
 
 from scargo.commands.build import scargo_build
-from scargo.config import Config
+from scargo.config import Config, Target
+from tests.ut.utils import get_log_data, get_test_project_config
 
 
+def register_common_commands(fp: FakeProcess) -> None:
+    fp.register(["conan", "profile", "list"])
+    fp.register(["conan", "profile", "detect"])
+    fp.register(["conan", "remote", "list-users"])
+    fp.register(["conan", "source", "."])
+
+
+def register_build_cmds(
+    fp: FakeProcess,
+    target: Target,
+    profile: str,
+    build_dir: Path,
+    build_fails: bool = False,
+) -> None:
+    profile_name = f"{target.id}_{profile}"
+    profile_path = f"./config/conan/profiles/{profile_name}"
+    copy_dir_path = Path(build_dir, "build", profile)
+    fp.register(
+        [
+            "conan",
+            "install",
+            ".",
+            "-pr",
+            profile_path,
+            "-of",
+            build_dir,
+            "-b",
+            "missing",
+        ]
+    )
+    fp.register(
+        ["conan", "build", ".", "-pr", profile_path, "-of", build_dir],
+        returncode=int(build_fails),
+    )
+    fp.register(["cp", "-r", "-l", "-f", f"{copy_dir_path}/*", "."])
+
+
+@pytest.mark.parametrize(
+    "profile", ["Debug", "Release", "MinSizeRel", "RelWithDebInfo"]
+)
 def test_scargo_build_dir_exist(
-    fp: FakeProcess, fs: FakeFilesystem, mock_prepare_config: MagicMock
+    profile: str, fp: FakeProcess, fs: FakeFilesystem, mock_prepare_config: MagicMock
+) -> None:
+    config = mock_prepare_config.return_value
+    target = config.project.default_target
+    build_dir = Path(target.get_profile_build_dir(profile))
+    Path("CMakeLists.txt").touch()
+
+    register_common_commands(fp)
+    register_build_cmds(fp, target, profile, build_dir)
+
+    scargo_build(profile, None)
+    assert build_dir.is_dir()
+
+
+def test_scargo_build_no_cmake(
+    fp: FakeProcess,
+    fs: FakeFilesystem,
+    mock_prepare_config: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    profile = "Debug"
+    with pytest.raises(SystemExit):
+        scargo_build(profile, None)
+    log_data = get_log_data(caplog.records)
+    assert ("ERROR", "File `CMakeLists.txt` does not exist.") in log_data
+    assert ("INFO", "Did you run `scargo update`?") in log_data
+
+
+def test_scargo_build_fails(
+    fp: FakeProcess,
+    fs: FakeFilesystem,
+    mock_prepare_config: MagicMock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     profile = "Debug"
     config = mock_prepare_config.return_value
     target = config.project.default_target
     build_dir = Path(target.get_profile_build_dir(profile))
     Path("CMakeLists.txt").touch()
-    fp.keep_last_process(True)
-    # any command can be called
-    fp.register([fp.any()])
-    scargo_build(profile, None)
-    assert build_dir.is_dir()
+
+    register_common_commands(fp)
+    register_build_cmds(fp, target, profile, build_dir, build_fails=True)
+
+    with pytest.raises(SystemExit):
+        scargo_build(profile, None)
+    log_data = get_log_data(caplog.records)
+    assert ("ERROR", "Scargo build target x86 failed") in log_data
+
+
+def test_scargo_build_all_targets(
+    fp: FakeProcess,
+    mock_prepare_multitarget_config: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    profile = "Debug"
+    config = mock_prepare_multitarget_config.return_value
+    Path("CMakeLists.txt").touch()
+    build_dirs = []
+
+    register_common_commands(fp)
+    for target in config.project.target:
+        build_dir = Path.cwd() / target.get_profile_build_dir(profile)
+        build_dirs.append(build_dir)
+        register_build_cmds(fp, target, profile, build_dir)
+
+    scargo_build(profile, None, all_targets=True)
+    for build_dir in build_dirs:
+        assert build_dir.is_dir()
+
+
+@pytest.fixture
+def mock_prepare_multitarget_config(tmpdir: Path, mocker: MockerFixture) -> MagicMock:
+    os.chdir(tmpdir)
+
+    multitarget_config = get_test_project_config("multitarget")
+    multitarget_config.project_root = Path(tmpdir)
+
+    return mocker.patch(
+        f"{scargo_build.__module__}.prepare_config", return_value=multitarget_config
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
Add -a, --all flag to scargo build command to build all targets. 

<pre>
Usage: scargo build [OPTIONS]

  Compile sources.

Options:
  -p, --profile PROFILE           [default: Debug]
  -t, --target [atsam|esp32|stm32|x86]
                                  Target device. Defaults to first one from
                                  toml if not specified.
  <b>-a, --all                       Build all targets.</b>
  -B, --base-dir DIRECTORY        Base directory of the project
  -h, --help                      Show this message and exit.
</pre>