### PR TITLE
420: use hard links instead of copying build folder

### DIFF
--- a/scargo/commands/build.py
+++ b/scargo/commands/build.py
@@ -6,7 +6,6 @@
 import subprocess
 import sys
 from pathlib import Path
-from shutil import copytree
 from typing import List, Optional
 
 from scargo.config import Config, ScargoTarget, Target
@@ -96,10 +95,11 @@ def _scargo_build_targets(config: Config, profile: str, targets: List[Target]) -
             logger.info("Copying artifacts...")
             # This is a workaround so that different profiles can work together with conan
             # Conan always calls CMake with '
-            copytree(
-                f"{build_dir}/build/{config.profiles[profile].cmake_build_type}",
-                build_dir,
-                dirs_exist_ok=True,
+            subprocess.run(
+                f"cp -r -l -f -P {build_dir}/build/{config.profiles[profile].cmake_build_type}/* .",
+                cwd=build_dir,
+                shell=True,
+                check=True,
             )
             logger.info("Artifacts copied")
 


### PR DESCRIPTION
`copytree` was introduced before due to errors when `cp -r -l` had been used to copy build folder with symbolic links to other file systems. `copytree` just copies the files - so it takes time and consumes a lot of disk space.

The current fix restores original `cp -r -l` copying by creating hardlinks but also adds flag `-P` which does not derefrences symbolic links - so they are copied instead of copying pointed file.

Now - the whole folder is copied (with hard links) as before and there is no more bug reported when esp-idf is upgraded to 5.1