### PR TITLE
feature: add bank switching

### DIFF
--- a/docs/source/scargo/scargo-flash.rst
+++ b/docs/source/scargo/scargo-flash.rst
@@ -47,13 +47,20 @@ Flash app only. Releavant only for esp32 projects.
 
 --fs           [default: false]
 
-Flash filesystem only. Releavant only for esp32 projects
+Flash filesystem only. Relevant only for esp32 projects
 
 ::
 
 --no-erase           [default: false]
 
-Don't erase target memory. Releavant only for stm32 projects
+Don't erase target memory. Relevant only for stm32 projects
+
+::
+
+--bank
+
+Switch between app flash banks. If the bank is not defined then no switch action will be done. Relevant only for stm32 projects
+Example usage:  scargo flash --bank 0
 
 ::
 

--- a/run.py
+++ b/run.py
@@ -310,7 +310,7 @@ def run_mypy() -> None:
 
 def main() -> None:  # pylint: disable=R0912
     args = get_cmdline_arguments()
-    if not len(sys.argv) > 1:
+    if len(sys.argv) <= 1:
         args.run_all = True
 
     if args.run_all:

--- a/scargo/cli.py
+++ b/scargo/cli.py
@@ -251,12 +251,17 @@ def flash(
     app: bool = Option(False, "--app", help="Flash app only"),
     file_system: bool = Option(False, "--fs", help="Flash filesystem only"),
     no_erase: bool = Option(False, help="(stm32 only) Don't erase target memory"),
+    bank: Optional[int] = Option(
+        None,
+        "--bank",
+        help="(esp32 only) Provide app flasg bank number for chosen target e.g. --bank 0",
+    ),
     base_dir: Optional[Path] = BASE_DIR_OPTION,
 ) -> None:
     """Flash the target."""
     if base_dir:
         os.chdir(base_dir)
-    scargo_flash(flash_profile, port, target, app, file_system, not no_erase)
+    scargo_flash(flash_profile, port, target, app, file_system, not no_erase, bank)
 
 
 ###############################################################################

--- a/scargo/commands/flash.py
+++ b/scargo/commands/flash.py
@@ -248,7 +248,7 @@ def scargo_flash(
     app: bool,
     file_system: bool,
     erase_memory: bool,
-    bank: Optional[int],
+    bank: Optional[int] = None,
 ) -> None:
     flasher = _ScargoFlash(
         flash_profile, port, target, app, file_system, erase_memory, bank

--- a/scargo/commands/flash.py
+++ b/scargo/commands/flash.py
@@ -39,12 +39,14 @@ class _ScargoFlash:
         app: bool,
         file_system: bool,
         erase_memory: bool,
+        bank: Optional[int],
     ):
         self._flash_profile = flash_profile
         self._port = port
         self._app = app
         self._file_system = file_system
         self._erase_memory = erase_memory
+        self._bank = bank
 
         self._config = prepare_config()
         self._target = self._initialize_target(target)
@@ -137,6 +139,10 @@ class _ScargoFlash:
                 self._flash_esp32_fs()
             else:
                 self._flash_esp32_default()
+
+            if self._bank is not None:
+                self._switch_bank_esp32()
+
         except subprocess.CalledProcessError as e:
             logger.error("Failed to flash esp32 target: %s", e.stderr)
             sys.exit(1)
@@ -223,6 +229,17 @@ class _ScargoFlash:
         command.extend(extra_args)
         return command
 
+    def _switch_bank_esp32(self) -> None:
+        command = ["otatool.py", "switch_ota_partition", "--slot", str(self._bank)]
+
+        try:
+            logger.info("Bank switching to: [%d]", self._bank)
+            subprocess.run(command, cwd=self._config.project_root, check=True)
+        except subprocess.CalledProcessError as e:
+            logger.error("Command failed with return code %s", str(e.returncode))
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error("An error occurred: %s", str(e))
+
 
 def scargo_flash(
     flash_profile: str,
@@ -231,6 +248,9 @@ def scargo_flash(
     app: bool,
     file_system: bool,
     erase_memory: bool,
+    bank: Optional[int],
 ) -> None:
-    flasher = _ScargoFlash(flash_profile, port, target, app, file_system, erase_memory)
+    flasher = _ScargoFlash(
+        flash_profile, port, target, app, file_system, erase_memory, bank
+    )
     flasher.flash_target()

--- a/scargo/logger.py
+++ b/scargo/logger.py
@@ -23,11 +23,11 @@ def __get_logging_config() -> Tuple[int, int]:
         scargo_config = config.scargo
         console_log_level = logging.getLevelName(scargo_config.console_log_level)
         file_log_level = logging.getLevelName(scargo_config.file_log_level)
-    finally:
-        return (  # pylint: disable=lost-exception
-            console_log_level,
-            file_log_level,
-        )
+    except Exception:  # pylint: disable=broad-except
+        console_log_level = logging.INFO
+        file_log_level = logging.WARNING
+
+    return (console_log_level, file_log_level)
 
 
 def get_logger(name: str = "scargo") -> logging.Logger:

--- a/scargo/logger.py
+++ b/scargo/logger.py
@@ -24,7 +24,7 @@ def __get_logging_config() -> Tuple[int, int]:
         console_log_level = logging.getLevelName(scargo_config.console_log_level)
         file_log_level = logging.getLevelName(scargo_config.file_log_level)
     finally:
-        return (  # pylint: disable=[lost-exception,return-in-finally]
+        return (  # pylint: disable=lost-exception
             console_log_level,
             file_log_level,
         )

--- a/tests/ut/ut_scargo_flash.py
+++ b/tests/ut/ut_scargo_flash.py
@@ -32,7 +32,7 @@ def test_flash_project_unsupported_target(
     mock_debug_config: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     with pytest.raises(SystemExit):
-        scargo_flash("Debug", None, None, False, False, False)
+        scargo_flash("Debug", None, None, False, False, False, None)
     assert (
         "ERROR",
         "Project does not contain target that supports flashing",
@@ -43,7 +43,7 @@ def test_flash_unsupported_target_argument(
     mock_debug_config: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     with pytest.raises(SystemExit):
-        scargo_flash("Debug", None, ScargoTarget.x86, False, False, False)
+        scargo_flash("Debug", None, ScargoTarget.x86, False, False, False, None)
     assert (
         "ERROR",
         "Flash command not supported for this target yet.",
@@ -54,7 +54,7 @@ def test_flash_target_argument_not_in_config(
     mock_debug_config: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     with pytest.raises(SystemExit):
-        scargo_flash("Debug", None, ScargoTarget.stm32, False, False, False)
+        scargo_flash("Debug", None, ScargoTarget.stm32, False, False, False, None)
     assert (
         "ERROR",
         "Target stm32 not defined in scargo toml",
@@ -93,6 +93,7 @@ def test_flash_stm32(
         app=False,
         file_system=False,
         erase_memory=False,
+        bank=None,
     )
 
 
@@ -130,6 +131,7 @@ def test_flash_stm32_port_defined(
         app=False,
         file_system=False,
         erase_memory=False,
+        bank=None,
     )
 
 
@@ -166,6 +168,7 @@ def test_flash_stm32_erase_memory(
         app=False,
         file_system=False,
         erase_memory=True,
+        bank=None,
     )
 
 
@@ -204,6 +207,7 @@ def test_flash_stm32_erase_memory_port_defined(
         app=False,
         file_system=False,
         erase_memory=True,
+        bank=None,
     )
 
 
@@ -258,6 +262,7 @@ def test_flash_esp32_default(
         app=False,
         file_system=False,
         erase_memory=False,
+        bank=None,
     )
 
 
@@ -284,6 +289,7 @@ def test_flash_esp32_port_defined(
         app=False,
         file_system=False,
         erase_memory=False,
+        bank=None,
     )
 
 
@@ -311,6 +317,7 @@ def test_flash_esp32_app(mock_debug_config: MagicMock, fp: FakeProcess) -> None:
         app=True,
         file_system=False,
         erase_memory=False,
+        bank=None,
     )
 
 
@@ -332,6 +339,7 @@ def test_flash_esp32_fs(mock_debug_config: MagicMock, fp: FakeProcess) -> None:
         app=False,
         file_system=True,
         erase_memory=False,
+        bank=None,
     )
 
 
@@ -355,6 +363,7 @@ def test_flash_elf_path_does_not_exist(
             app=False,
             file_system=False,
             erase_memory=False,
+            bank=None,
         )
     log_data = get_log_data(caplog.records)
     assert ("ERROR", f"{elf_path.absolute()} does not exist") in log_data
@@ -384,6 +393,7 @@ def test_flash_bin_path_does_not_exist(
             app=False,
             file_system=False,
             erase_memory=False,
+            bank=None,
         )
     log_data = get_log_data(caplog.records)
     assert ("ERROR", f"{bin_path.absolute()} does not exist") in log_data


### PR DESCRIPTION
add new option to switch between app flash banks - for now only available for esp32.
Example usage:  scargo flash --bank 0

If bank is not define then no switch action will be done