### PR TITLE
Documentation - UML and miscellaneous fixes

### DIFF
--- a/docs/source/arch/scargo_common_seq.puml
+++ b/docs/source/arch/scargo_common_seq.puml
@@ -12,8 +12,5 @@ participant sc_build #Application
 participant conan #Implementation
 participant cmake #Implementation
 participant esp_idf #Implementation
-participant storage #Physical [
-    <<local storage>>
-    my_project_1
-]
+participant "my_project_1" as storage  << (S,#ADD1B2) local storage >> #Physical
 participant "package repository" as pkg_repo #Strategy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,9 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = []
+exclude_patterns: List[str] = [
+	r"modules/*.rst" # ignore any warning from modules
+]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/scargo/scargo-monitor.rst
+++ b/docs/source/scargo/scargo-monitor.rst
@@ -1,7 +1,7 @@
 .. _scargo_monitor:
 
 Connect and monitor the serial interface.
------------------------------------
+-----------------------------------------
 
 Usage
 ^^^^^


### PR DESCRIPTION
**Documentation - UML and miscellaneous fixes**

Bug fixes in documentation generator for UML diagrams and general sphinx warnings.

**Changes:**
- disabled warnings coming from `docs/source/modules/`,
- fix for too short underline in `docs/source/scargo/scargo-monitor.rst`,
- fix for invalid syntax for participant "storage" in `docs/source/arch/scargo_common_seq.puml`  causing UML generators to fail in `docs/source/arch/arch-interaction.rst`.


A non-descriptive error message for failing UML generator:

> /scargo/scargo/docs/source/arch/arch-interaction.rst:42: WARNING: error while running plantuml
> b'ERROR\n14\nSyntax Error?\nSome diagram description contains errors\n'
> /scargo/scargo/docs/source/arch/arch-interaction.rst:68: WARNING: error while running plantuml
> b'ERROR\n14\nSyntax Error?\nSome diagram description contains errors\n'