### PR TITLE
Unit tests - improved GCOV detailed coverage for all source files

### DIFF
--- a/scargo/commands/new.py
+++ b/scargo/commands/new.py
@@ -14,7 +14,12 @@ from scargo.config import CHIP_DEFAULTS, TARGETS, ScargoTarget, Target
 from scargo.config_utils import get_scargo_config_or_exit
 from scargo.file_generators.cpp_gen import generate_cpp
 from scargo.file_generators.toml_gen import generate_toml
-from scargo.global_values import SCARGO_DEFAULT_CONFIG_FILE, SCARGO_DOCKER_ENV
+from scargo.global_values import (
+    SCARGO_DEFAULT_CONFIG_FILE,
+    SCARGO_DOCKER_ENV,
+    SCARGO_HEADER_EXTENSIONS_DEFAULT,
+    SCARGO_SRC_EXTENSIONS_DEFAULT,
+)
 from scargo.logger import get_logger
 from scargo.target_helpers.atsam_helper import create_atsam_config
 from scargo.target_helpers.esp32_helper import create_esp32_config
@@ -116,6 +121,8 @@ def scargo_new(
         docker_image_tag=f"{name.lower()}-dev:1.0",
         lib_name=lib_name,
         bin_name=bin_name,
+        src_extensions=SCARGO_SRC_EXTENSIONS_DEFAULT,
+        header_extensions=SCARGO_HEADER_EXTENSIONS_DEFAULT,
         atsam_config=create_atsam_config(targets_chips.get("atsam")),
         esp32_config=create_esp32_config(targets_chips.get("esp32")),
         stm32_config=create_stm32_config(targets_chips.get("stm32")),

--- a/scargo/commands/test.py
+++ b/scargo/commands/test.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Union
 from scargo.config import Config
 from scargo.config_utils import prepare_config
 from scargo.file_generators.conan_gen import conan_add_default_profile_if_missing
-from scargo.global_values import SCARGO_SRC_EXTENSIONS
+from scargo.global_values import SCARGO_SRC_EXTENSIONS_DEFAULT
 from scargo.logger import get_logger
 from scargo.utils.conan_utils import conan_add_remote, conan_source
 
@@ -111,7 +111,7 @@ def _gcov_get_uncovered_src_files(
     for ff in config.source_dir_path.rglob("*"):
         if not ff.is_file():
             continue
-        if ff.suffix not in SCARGO_SRC_EXTENSIONS:
+        if ff.suffix not in SCARGO_SRC_EXTENSIONS_DEFAULT:
             continue
         if ff in covered_files:
             continue

--- a/scargo/commands/test.py
+++ b/scargo/commands/test.py
@@ -107,11 +107,21 @@ def _gcov_get_uncovered_src_files(
     for ff in output_json["files"]:
         covered_files.append(Path(config.source_dir_path) / Path(ff["file"]).name)
 
+    accepted_extensions = config.project.src_extensions
+    if not accepted_extensions:
+        accepted_extensions = SCARGO_SRC_EXTENSIONS_DEFAULT
+        logger.warning(
+            "scargo: test: source file extensions not defined in the config file 'scargo.toml'."
+        )
+        logger.warning(
+            f"scargo: test: default extensions in use: '{SCARGO_SRC_EXTENSIONS_DEFAULT}'"
+        )
+
     uncovered_files: List[Path] = []
     for ff in config.source_dir_path.rglob("*"):
         if not ff.is_file():
             continue
-        if ff.suffix not in SCARGO_SRC_EXTENSIONS_DEFAULT:
+        if ff.suffix not in accepted_extensions:
             continue
         if ff in covered_files:
             continue

--- a/scargo/config.py
+++ b/scargo/config.py
@@ -3,12 +3,17 @@
 # #
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import toml
 from pydantic import BaseModel, Extra, Field, root_validator
 
-from scargo.global_values import SCARGO_DEFAULT_BUILD_ENV, SCARGO_DOCKER_ENV
+from scargo.global_values import (
+    SCARGO_DEFAULT_BUILD_ENV,
+    SCARGO_DOCKER_ENV,
+    SCARGO_HEADER_EXTENSIONS_DEFAULT,
+    SCARGO_SRC_EXTENSIONS_DEFAULT,
+)
 
 
 class ScargoTarget(Enum):
@@ -155,6 +160,9 @@ class ProjectConfig(BaseModel):
 
     cflags: str
     cxxflags: str
+
+    src_extensions: Optional[Sequence[str]] = SCARGO_SRC_EXTENSIONS_DEFAULT
+    header_extensions: Optional[Sequence[str]] = SCARGO_HEADER_EXTENSIONS_DEFAULT
 
     max_build_jobs: Optional[int] = Field(default=None, alias="max-build-jobs")
     cmake_variables: Dict[str, str] = Field(default={}, alias="cmake-variables")

--- a/scargo/config.py
+++ b/scargo/config.py
@@ -8,12 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 import toml
 from pydantic import BaseModel, Extra, Field, root_validator
 
-from scargo.global_values import (
-    SCARGO_DEFAULT_BUILD_ENV,
-    SCARGO_DOCKER_ENV,
-    SCARGO_HEADER_EXTENSIONS_DEFAULT,
-    SCARGO_SRC_EXTENSIONS_DEFAULT,
-)
+from scargo.global_values import SCARGO_DEFAULT_BUILD_ENV, SCARGO_DOCKER_ENV
 
 
 class ScargoTarget(Enum):
@@ -161,8 +156,8 @@ class ProjectConfig(BaseModel):
     cflags: str
     cxxflags: str
 
-    src_extensions: Optional[Sequence[str]] = SCARGO_SRC_EXTENSIONS_DEFAULT
-    header_extensions: Optional[Sequence[str]] = SCARGO_HEADER_EXTENSIONS_DEFAULT
+    src_extensions: Optional[Sequence[str]]
+    header_extensions: Optional[Sequence[str]]
 
     max_build_jobs: Optional[int] = Field(default=None, alias="max-build-jobs")
     cmake_variables: Dict[str, str] = Field(default={}, alias="cmake-variables")

--- a/scargo/file_generators/templates/scargo.toml.j2
+++ b/scargo/file_generators/templates/scargo.toml.j2
@@ -26,6 +26,9 @@ cxxstandard = "17"
 cflags   = "-Wall -Wextra"
 cxxflags = "-Wall -Wextra"
 
+src_extensions = {{ src_extensions | tojson }}
+header_extensions = {{ header_extensions | tojson }}
+
 in-repo-conan-cache = false
 
 [profile.Debug]

--- a/scargo/file_generators/ut_gen.py
+++ b/scargo/file_generators/ut_gen.py
@@ -7,7 +7,10 @@ from typing import List, Sequence
 from scargo.config import Config
 from scargo.file_generators.base_gen import create_file_from_template
 from scargo.file_generators.clang_parser.header_parser import parse_file
-from scargo.global_values import SCARGO_HEADER_EXTENSIONS, SCARGO_SRC_EXTENSIONS
+from scargo.global_values import (
+    SCARGO_HEADER_EXTENSIONS_DEFAULT,
+    SCARGO_SRC_EXTENSIONS_DEFAULT,
+)
 from scargo.utils.sys_utils import removeprefix
 
 
@@ -29,7 +32,9 @@ class _UnitTestsGen:
             self._generate_cmake(input_path.parent, ut_path.parent)
 
         elif input_path.is_dir():
-            headers = self._get_paths_with_ext(input_path, SCARGO_HEADER_EXTENSIONS)
+            headers = self._get_paths_with_ext(
+                input_path, SCARGO_HEADER_EXTENSIONS_DEFAULT
+            )
             ut_path = None
             for hdr in headers:
                 ut_path = self._get_unit_test_path(hdr)
@@ -68,7 +73,10 @@ class _UnitTestsGen:
 
         ut_name = self._get_cmake_tests_name(ut_dir_path)
         ut_files = [
-            p.name for p in self._get_paths_with_ext(ut_dir_path, SCARGO_SRC_EXTENSIONS)
+            p.name
+            for p in self._get_paths_with_ext(
+                ut_dir_path, SCARGO_SRC_EXTENSIONS_DEFAULT
+            )
         ]
 
         src_path = removeprefix(
@@ -85,7 +93,9 @@ class _UnitTestsGen:
 
         src_files = [
             p.relative_to(self._project_path)
-            for p in self._get_paths_with_ext(src_dir_path, SCARGO_SRC_EXTENSIONS)
+            for p in self._get_paths_with_ext(
+                src_dir_path, SCARGO_SRC_EXTENSIONS_DEFAULT
+            )
             if p.name != main_cpp
         ]
 

--- a/scargo/file_generators/ut_gen.py
+++ b/scargo/file_generators/ut_gen.py
@@ -7,10 +7,8 @@ from typing import List, Sequence
 from scargo.config import Config
 from scargo.file_generators.base_gen import create_file_from_template
 from scargo.file_generators.clang_parser.header_parser import parse_file
+from scargo.global_values import SCARGO_HEADER_EXTENSIONS, SCARGO_SRC_EXTENSIONS
 from scargo.utils.sys_utils import removeprefix
-
-HEADER_EXTENSIONS = (".h", ".hpp")
-SRC_EXTENSIONS = (".c", ".cpp")
 
 
 class _UnitTestsGen:
@@ -31,7 +29,7 @@ class _UnitTestsGen:
             self._generate_cmake(input_path.parent, ut_path.parent)
 
         elif input_path.is_dir():
-            headers = self._get_paths_with_ext(input_path, HEADER_EXTENSIONS)
+            headers = self._get_paths_with_ext(input_path, SCARGO_HEADER_EXTENSIONS)
             ut_path = None
             for hdr in headers:
                 ut_path = self._get_unit_test_path(hdr)
@@ -70,7 +68,7 @@ class _UnitTestsGen:
 
         ut_name = self._get_cmake_tests_name(ut_dir_path)
         ut_files = [
-            p.name for p in self._get_paths_with_ext(ut_dir_path, SRC_EXTENSIONS)
+            p.name for p in self._get_paths_with_ext(ut_dir_path, SCARGO_SRC_EXTENSIONS)
         ]
 
         src_path = removeprefix(
@@ -87,7 +85,7 @@ class _UnitTestsGen:
 
         src_files = [
             p.relative_to(self._project_path)
-            for p in self._get_paths_with_ext(src_dir_path, SRC_EXTENSIONS)
+            for p in self._get_paths_with_ext(src_dir_path, SCARGO_SRC_EXTENSIONS)
             if p.name != main_cpp
         ]
 

--- a/scargo/global_values.py
+++ b/scargo/global_values.py
@@ -19,5 +19,5 @@ SCARGO_LOCK_FILE = "scargo.lock"
 SCARGO_DEFAULT_CONFIG_FILE = "scargo.toml"
 ENV_DEFAULT_NAME = ".env"
 
-SCARGO_HEADER_EXTENSIONS = (".h", ".hpp")
-SCARGO_SRC_EXTENSIONS = (".c", ".cpp")
+SCARGO_HEADER_EXTENSIONS_DEFAULT = (".h", ".hpp", ".hxx", ".hh", ".inc", ".inl")
+SCARGO_SRC_EXTENSIONS_DEFAULT = (".c", ".cpp", ".cxx", ".cc", ".s", ".S", ".asm")

--- a/scargo/global_values.py
+++ b/scargo/global_values.py
@@ -18,3 +18,6 @@ SCARGO_DOCKER_ENV = "docker"
 SCARGO_LOCK_FILE = "scargo.lock"
 SCARGO_DEFAULT_CONFIG_FILE = "scargo.toml"
 ENV_DEFAULT_NAME = ".env"
+
+SCARGO_HEADER_EXTENSIONS = (".h", ".hpp")
+SCARGO_SRC_EXTENSIONS = (".c", ".cpp")


### PR DESCRIPTION
**Description:**

GCOV detailed coverage for unit tests has been improved by generating default report of 0.0% for each uncovered source file.

By default, GCOV generates coverage records only for source files included in the unit tests. To generate detailed coverage for all source files, an output JSON file is first generated from GCOV, then the JSON file is updated with empty records for each uncovered source file, and the final HTML output report is regenerated using the modified output JSON.

Moreover, GCOV output records with 0.0% coverage can be restricted to uncovered files with the required extensions, based on two variables in the config file called `src_extensions` and `header_extensions`. 

**Changes:**
- `commands/test`: improved detailed coverage for unit tests by generating default report 0.0% for uncovered source files (based on predefined C/C++ file extensions),
- `file_generators/ut_gen`: source and header extensions constants moved to shared `global_values.py`,
- `config`: toml generator updated with source and header file extensions variables to filter out files in GCOV coverage report,
- `global_values`: updated source and header file extension variables, and renamed with suffix "_DEFAULT" (no functional changes).

Example:
![image](https://github.com/user-attachments/assets/9d72b96e-a315-4068-a07f-515feb9ed027)
