### PR TITLE
commands/update: always clean project after updating

### DIFF
--- a/scargo/commands/update.py
+++ b/scargo/commands/update.py
@@ -48,10 +48,6 @@ def scargo_update(config_file_path: Path) -> None:
     vscode_path = Path(project_path, ".vscode")
     config = get_scargo_config_or_exit(config_file_path)
 
-    # Always clean project before updating to avoid cache conflicts with artefacts
-    # from previous builds
-    scargo_clean()
-
     # Copy templates project files to repo directory
     copy_file_if_not_exists(project_path)
 
@@ -88,6 +84,10 @@ def scargo_update(config_file_path: Path) -> None:
     generate_cicd(config)
     generate_tests(config)
     generate_readme(config)
+
+    # Always clean project after updating to avoid cache conflicts with artefacts
+    # from previous builds
+    scargo_clean()
 
     # do not rebuild dockers in the docker
     if project_config.is_docker_buildenv():

--- a/scargo/commands/update.py
+++ b/scargo/commands/update.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from scargo.commands.clean import scargo_clean
 from scargo.commands.docker import get_docker_compose_command, scargo_docker_build
 from scargo.config_utils import add_version_to_scargo_lock, get_scargo_config_or_exit
 from scargo.file_generators.cicd_gen import generate_cicd
@@ -46,6 +47,10 @@ def scargo_update(config_file_path: Path) -> None:
     docker_path = Path(project_path, ".devcontainer")
     vscode_path = Path(project_path, ".vscode")
     config = get_scargo_config_or_exit(config_file_path)
+
+    # Always clean project before updating to avoid cache conflicts with artefacts
+    # from previous builds
+    scargo_clean()
 
     # Copy templates project files to repo directory
     copy_file_if_not_exists(project_path)


### PR DESCRIPTION
**Description:**

The `update` command has been updated with `clean` command to avoid cache conflicts with artifacts from previous compilations. 

Example of the problem:

After changing `project.build-env="docker"` to `project.build-env="native"`, calling `scargo update; scargo build` generates:

```
[...]

======== Calling build() ========
conanfile.py (x86test/0.1.0): Calling build()
conanfile.py (x86test/0.1.0): Running CMake.configure()
conanfile.py (x86test/0.1.0): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/workspace/build/x86/Debug" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Debug" "/workspace"

CMake Error: The current CMakeCache.txt directory /workspace/build/x86/Debug/build/Debug/CMakeCache.txt is different than the directory ~/spyro/scargo/test/x86test/build/x86/Debug/build/Debug where CMakeCache.txt was created. This may result in binaries being created in the wrong place. If you are not sure, reedit the CMakeCache.txt

CMake Error: The source "/workspace/CMakeLists.txt" does not match the source "~/spyro/scargo/test/x86test/CMakeLists.txt" used to generate cache.  Re-run cmake with a different source directory.

ERROR: conanfile.py (x86test/0.1.0): Error in build() method, line 30
	cmake.configure()
	ConanException: Error 1 while executing
scargo ERROR: Scargo build target x86 failed
```
 