### PR TITLE
commands/update: added warning about potential cache conflicts in build folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ exclude = [
 [tool.isort]
 profile = "black"
 
+[tool.black]
+line-length = 120
+
 [tool.pylint]
 ignore-paths = ["example_project", "tests"]
 max-line-length = 120

--- a/scargo/commands/update.py
+++ b/scargo/commands/update.py
@@ -72,9 +72,7 @@ def scargo_update(config_file_path: Path) -> None:
         with open(Path(project_path, "version.txt"), "w", encoding="utf-8") as out:
             out.write(project_config.version)
         with open(Path(project_path, "partitions.csv"), "w", encoding="utf-8") as out:
-            out.write(
-                "# ESP-IDF Partition Table\n# Name,   Type, SubType, Offset,  Size, Flags\n"
-            )
+            out.write("# ESP-IDF Partition Table\n# Name,   Type, SubType, Offset,  Size, Flags\n")
             partitions = config.get_esp32_config().partitions
             for line in partitions:
                 out.write(line + "\n")
@@ -92,6 +90,17 @@ def scargo_update(config_file_path: Path) -> None:
         else:
             logger.warning("Cannot run docker inside docker")
 
+    build_dir = config.project_root / "build"
+    if not build_dir.exists():
+        return
+
+    build_dir_empty = not any(build_dir.iterdir())
+    if build_dir_empty:
+        return
+
+    logger.warning("Project build folder was not empty before the update.")
+    logger.warning("Potential cache conflicts with the previous build - use 'clean' command in case of problems.")
+
 
 def pull_docker_image(docker_path: Path) -> bool:
     logger.info("Pulling the image from docker registry...")
@@ -105,15 +114,10 @@ def pull_docker_image(docker_path: Path) -> bool:
             check=True,
         )
     except subprocess.CalledProcessError:
-        logger.info(
-            "No docker image does exist yet in the registry or you are not login"
-        )
+        logger.info("No docker image does exist yet in the registry or you are not login")
     else:
         # happens for the default tag, like "myproject-dev:1.0"
-        if (
-            "Some service image(s) must be built from source"
-            not in result.stderr.decode()
-        ):
+        if "Some service image(s) must be built from source" not in result.stderr.decode():
             logger.info("Docker image pulled successfully")
             return True
     return False


### PR DESCRIPTION
**Description:**

The update command has been updated with a warning message about potential cache conflicts with artifacts from previous compilations.

**Changes:**
- `scargo/commands/update.py`: added message warning about potential cache conflicts if the build directory existed before the update,
- `pyproject.toml`: blake formatter: line length set to 120 (compatibility with flake8).

**Example of the problem:**

After changing project.build-env="docker" to project.build-env="native", calling scargo update; scargo build generates:
```
[...]

======== Calling build() ========
conanfile.py (x86test/0.1.0): Calling build()
conanfile.py (x86test/0.1.0): Running CMake.configure()
conanfile.py (x86test/0.1.0): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/workspace/build/x86/Debug" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Debug" "/workspace"

CMake Error: The current CMakeCache.txt directory /workspace/build/x86/Debug/build/Debug/CMakeCache.txt is different than the directory ~/spyro/scargo/test/x86test/build/x86/Debug/build/Debug where CMakeCache.txt was created. This may result in binaries being created in the wrong place. If you are not sure, reedit the CMakeCache.txt

CMake Error: The source "/workspace/CMakeLists.txt" does not match the source "~/spyro/scargo/test/x86test/CMakeLists.txt" used to generate cache.  Re-run cmake with a different source directory.

ERROR: conanfile.py (x86test/0.1.0): Error in build() method, line 30
	cmake.configure()
	ConanException: Error 1 while executing
scargo ERROR: Scargo build target x86 failed
```