### PR TITLE
pyproject.toml: optional-dependencies: matplotlib version set to v3.7.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "flake8>=6.1.0",
     "flit==3.8.0",
     "isort==5.11.4",
-    "matplotlib",
+    "matplotlib==3.7.5",
     "mypy==1.14.1",
     "pre-commit",
     "pyclean==3.0.0",


### PR DESCRIPTION
**Description:**

Package `matplotlib` version set to v3.7.5 for compatibility with `ci/requirements.txt` to avoid problems between local dev environments and CI/CD server - no functional changes.