### PR TITLE
Logging: "print()" calls replaced with logger

### DIFF
--- a/scargo/commands/monitor.py
+++ b/scargo/commands/monitor.py
@@ -92,7 +92,7 @@ class SerialReadThread(threading.Thread):
         try:
             s = self.ser.read(self.read_block_size)
             if s:
-                print(s.decode())
+                logger.info(s.decode())
             self.error_count = 0
         except serial.SerialTimeoutException as e:
             # Handle timeout specifically

--- a/scargo/commands/test.py
+++ b/scargo/commands/test.py
@@ -42,7 +42,7 @@ def scargo_test(verbose: bool, profile: str = "Debug", detailed_coverage: bool =
 
     if not Path(tests_src_dir, "CMakeLists.txt").exists():
         logger.error("Directory `tests`: File `CMakeLists.txt` does not exist.")
-        logger.info("Did you run `scargo update`?")
+        logger.error("Did you run `scargo update`?")
         sys.exit(1)
 
     test_build_dir.mkdir(parents=True, exist_ok=True)
@@ -176,7 +176,7 @@ def run_ut(config: Config, verbose: bool, cwd: Path, detailed_coverage: bool) ->
             cmd.append("--json")
             cmd.append(output_json_filename)
 
-        print(cmd)
+        logger.info(cmd)
 
         gcov_executable = config.tests.gcov_executable
         if gcov_executable != "":
@@ -213,7 +213,7 @@ def run_ut(config: Config, verbose: bool, cwd: Path, detailed_coverage: bool) ->
             "--json-add-tracefile",
             str(output_json_fpath),
         ]
-        print(cmd)
+        logger.info(cmd)
 
         gcov_executable = config.tests.gcov_executable
         if gcov_executable != "":

--- a/scargo/commands/version.py
+++ b/scargo/commands/version.py
@@ -4,7 +4,10 @@
 
 """feature function for scargo"""
 from scargo import __version__
+from scargo.logger import get_logger
+
+logger = get_logger()
 
 
 def scargo_version() -> None:
-    print(f"scargo version: {__version__}")
+    logger.info(f"scargo version: {__version__}")

--- a/scargo/file_generators/docker_gen.py
+++ b/scargo/file_generators/docker_gen.py
@@ -12,7 +12,10 @@ from scargo import __version__
 from scargo.config import Config
 from scargo.file_generators.base_gen import create_file_from_template
 from scargo.global_values import SCARGO_PKG_PATH
+from scargo.logger import get_logger
 from scargo.target_helpers import atsam_helper, stm32_helper
+
+logger = get_logger()
 
 
 class _DockerComposeTemplate:
@@ -32,13 +35,13 @@ class _DockerComposeTemplate:
                     scargo_path = Path(line.split("Location:")[1].strip()) / "scargo"
                     if scargo_path.exists():
                         return scargo_path
-                    print(f"Error: The scargo path {scargo_path} does not exist.")
+                    logger.error(f"Error: The scargo path {scargo_path} does not exist.")
         except subprocess.CalledProcessError as e:
-            print(f"Subprocess error while retrieving scargo path: {e}")
+            logger.error(f"Subprocess error while retrieving scargo path: {e}")
         except FileNotFoundError as e:
-            print(f"File not found: {e}")
+            logger.error(f"File not found: {e}")
         except OSError as e:
-            print(f"OS error occurred: {e}")
+            logger.error(f"OS error occurred: {e}")
 
         return Path()
 

--- a/scargo/utils/docker_utils.py
+++ b/scargo/utils/docker_utils.py
@@ -73,7 +73,7 @@ def run_command_in_docker(  # type: ignore[no-any-unimported]
     output = container.attach(stdout=True, stream=True, logs=True, stderr=True)
     output_str = ""
     for line in output:
-        print(line.decode(), end="")
+        logger.info(line.decode().removesuffix("\n"))
         output_str += line.decode()
     result = container.wait()
     container.remove()

--- a/scargo/utils/docker_utils.py
+++ b/scargo/utils/docker_utils.py
@@ -73,6 +73,9 @@ def run_command_in_docker(  # type: ignore[no-any-unimported]
     output = container.attach(stdout=True, stream=True, logs=True, stderr=True)
     output_str = ""
     for line in output:
+        # INFO: IT tests and their checks rely on stdout value and this cannot be removed.
+        # INFO: tests/it/it_scargo_commands_flow.py should be rewritten, to not rely on stdout.
+        print(line.decode(), end="")
         logger.info(line.decode().removesuffix("\n"))
         output_str += line.decode()
     result = container.wait()

--- a/tests/it/utils.py
+++ b/tests/it/utils.py
@@ -42,7 +42,6 @@ class ScargoTestRunner(CliRunner):
             **extra,
         )
         sys.argv = temp
-        print(result.output)
         return result
 
 


### PR DESCRIPTION
**Description:**

"print()" calls have been replaced with logger handlers - no functional changes.

**Changes:**
- `print()` calls replaced with logger handlers,
- `scargo/utils/docker_utils.py`: call _print(line.decode(), end="")_ replaced with _line.decode().removesuffix("\n")_,
- `scargo/utils/docker_utils.py`: restored removed _print()_ to pass integration test checks based on stdout.